### PR TITLE
0.5: Changes to `Parsed`

### DIFF
--- a/src/format/parse.rs
+++ b/src/format/parse.rs
@@ -628,14 +628,6 @@ mod tests {
     use crate::format::*;
     use crate::{DateTime, FixedOffset, NaiveDateTime, TimeZone, Timelike, Utc};
 
-    macro_rules! parsed {
-        ($($k:ident: $v:expr),*) => (#[allow(unused_mut)] {
-            let mut expected = Parsed::new();
-            $(expected.$k = Some($v);)*
-            Ok(expected)
-        });
-    }
-
     #[test]
     fn test_parse_whitespace_and_literal() {
         use crate::format::Item::{Literal, Space};
@@ -763,58 +755,60 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_numeric() {
+    fn test_parse_numeric() -> Result<(), ParseError> {
         use crate::format::Item::{Literal, Space};
         use crate::format::Numeric::*;
 
+        let p = Parsed::new;
+
         // numeric
-        check("1987", &[num(Year)], parsed!(year: 1987));
+        check("1987", &[num(Year)], p().set_year(1987));
         check("1987 ", &[num(Year)], Err(TOO_LONG));
         check("0x12", &[num(Year)], Err(TOO_LONG)); // `0` is parsed
         check("x123", &[num(Year)], Err(INVALID));
         check("o123", &[num(Year)], Err(INVALID));
-        check("2015", &[num(Year)], parsed!(year: 2015));
-        check("0000", &[num(Year)], parsed!(year: 0));
-        check("9999", &[num(Year)], parsed!(year: 9999));
+        check("2015", &[num(Year)], p().set_year(2015));
+        check("0000", &[num(Year)], p().set_year(0));
+        check("9999", &[num(Year)], p().set_year(9999));
         check(" \t987", &[num(Year)], Err(INVALID));
-        check(" \t987", &[Space(" \t"), num(Year)], parsed!(year: 987));
-        check(" \t987🤠", &[Space(" \t"), num(Year), Literal("🤠")], parsed!(year: 987));
-        check("987🤠", &[num(Year), Literal("🤠")], parsed!(year: 987));
-        check("5", &[num(Year)], parsed!(year: 5));
+        check(" \t987", &[Space(" \t"), num(Year)], p().set_year(987));
+        check(" \t987🤠", &[Space(" \t"), num(Year), Literal("🤠")], p().set_year(987));
+        check("987🤠", &[num(Year), Literal("🤠")], p().set_year(987));
+        check("5", &[num(Year)], p().set_year(5));
         check("5\0", &[num(Year)], Err(TOO_LONG));
         check("\x005", &[num(Year)], Err(INVALID));
         check("", &[num(Year)], Err(TOO_SHORT));
-        check("12345", &[num(Year), Literal("5")], parsed!(year: 1234));
-        check("12345", &[nums(Year), Literal("5")], parsed!(year: 1234));
-        check("12345", &[num0(Year), Literal("5")], parsed!(year: 1234));
-        check("12341234", &[num(Year), num(Year)], parsed!(year: 1234));
+        check("12345", &[num(Year), Literal("5")], p().set_year(1234));
+        check("12345", &[nums(Year), Literal("5")], p().set_year(1234));
+        check("12345", &[num0(Year), Literal("5")], p().set_year(1234));
+        check("12341234", &[num(Year), num(Year)], p().set_year(1234));
         check("1234 1234", &[num(Year), num(Year)], Err(INVALID));
-        check("1234 1234", &[num(Year), Space(" "), num(Year)], parsed!(year: 1234));
+        check("1234 1234", &[num(Year), Space(" "), num(Year)], p().set_year(1234));
         check("1234 1235", &[num(Year), num(Year)], Err(INVALID));
         check("1234 1234", &[num(Year), Literal("x"), num(Year)], Err(INVALID));
-        check("1234x1234", &[num(Year), Literal("x"), num(Year)], parsed!(year: 1234));
+        check("1234x1234", &[num(Year), Literal("x"), num(Year)], p().set_year(1234));
         check("1234 x 1234", &[num(Year), Literal("x"), num(Year)], Err(INVALID));
         check("1234xx1234", &[num(Year), Literal("x"), num(Year)], Err(INVALID));
-        check("1234xx1234", &[num(Year), Literal("xx"), num(Year)], parsed!(year: 1234));
+        check("1234xx1234", &[num(Year), Literal("xx"), num(Year)], p().set_year(1234));
         check(
             "1234 x 1234",
             &[num(Year), Space(" "), Literal("x"), Space(" "), num(Year)],
-            parsed!(year: 1234),
+            p().set_year(1234),
         );
         check(
             "1234 x 1235",
             &[num(Year), Space(" "), Literal("x"), Space(" "), Literal("1235")],
-            parsed!(year: 1234),
+            p().set_year(1234),
         );
 
         // signed numeric
-        check("-42", &[num(Year)], parsed!(year: -42));
-        check("+42", &[num(Year)], parsed!(year: 42));
-        check("-0042", &[num(Year)], parsed!(year: -42));
-        check("+0042", &[num(Year)], parsed!(year: 42));
-        check("-42195", &[num(Year)], parsed!(year: -42195));
+        check("-42", &[num(Year)], p().set_year(-42));
+        check("+42", &[num(Year)], p().set_year(42));
+        check("-0042", &[num(Year)], p().set_year(-42));
+        check("+0042", &[num(Year)], p().set_year(42));
+        check("-42195", &[num(Year)], p().set_year(-42195));
         check("−42195", &[num(Year)], Err(INVALID)); // MINUS SIGN (U+2212)
-        check("+42195", &[num(Year)], parsed!(year: 42195));
+        check("+42195", &[num(Year)], p().set_year(42195));
         check("  -42195", &[num(Year)], Err(INVALID));
         check(" +42195", &[num(Year)], Err(INVALID));
         check("  -42195", &[num(Year)], Err(INVALID));
@@ -823,109 +817,124 @@ mod tests {
         check("+42195 ", &[num(Year)], Err(TOO_LONG));
         check("  -   42", &[num(Year)], Err(INVALID));
         check("  +   42", &[num(Year)], Err(INVALID));
-        check("  -42195", &[Space("  "), num(Year)], parsed!(year: -42195));
+        check("  -42195", &[Space("  "), num(Year)], p().set_year(-42195));
         check("  −42195", &[Space("  "), num(Year)], Err(INVALID)); // MINUS SIGN (U+2212)
-        check("  +42195", &[Space("  "), num(Year)], parsed!(year: 42195));
+        check("  +42195", &[Space("  "), num(Year)], p().set_year(42195));
         check("  -   42", &[Space("  "), num(Year)], Err(INVALID));
         check("  +   42", &[Space("  "), num(Year)], Err(INVALID));
         check("-", &[num(Year)], Err(TOO_SHORT));
         check("+", &[num(Year)], Err(TOO_SHORT));
 
         // unsigned numeric
-        check("345", &[num(Ordinal)], parsed!(ordinal: 345));
+        check("345", &[num(Ordinal)], p().set_ordinal(345));
         check("+345", &[num(Ordinal)], Err(INVALID));
         check("-345", &[num(Ordinal)], Err(INVALID));
         check(" 345", &[num(Ordinal)], Err(INVALID));
         check("−345", &[num(Ordinal)], Err(INVALID)); // MINUS SIGN (U+2212)
         check("345 ", &[num(Ordinal)], Err(TOO_LONG));
-        check(" 345", &[Space(" "), num(Ordinal)], parsed!(ordinal: 345));
-        check("345 ", &[num(Ordinal), Space(" ")], parsed!(ordinal: 345));
-        check("345🤠 ", &[num(Ordinal), Literal("🤠"), Space(" ")], parsed!(ordinal: 345));
+        check(" 345", &[Space(" "), num(Ordinal)], p().set_ordinal(345));
+        check("345 ", &[num(Ordinal), Space(" ")], p().set_ordinal(345));
+        check("345🤠 ", &[num(Ordinal), Literal("🤠"), Space(" ")], p().set_ordinal(345));
         check("345🤠", &[num(Ordinal)], Err(TOO_LONG));
         check("\u{0363}345", &[num(Ordinal)], Err(INVALID));
         check(" +345", &[num(Ordinal)], Err(INVALID));
         check(" -345", &[num(Ordinal)], Err(INVALID));
-        check("\t345", &[Space("\t"), num(Ordinal)], parsed!(ordinal: 345));
+        check("\t345", &[Space("\t"), num(Ordinal)], p().set_ordinal(345));
         check(" +345", &[Space(" "), num(Ordinal)], Err(INVALID));
         check(" -345", &[Space(" "), num(Ordinal)], Err(INVALID));
 
         const S: Item = Space(" ");
         // various numeric fields
-        check("1234 5678", &[num(Year), S, num(IsoYear)], parsed!(year: 1234, isoyear: 5678));
-        check("1234 5678", &[num(Year), S, num(IsoYear)], parsed!(year: 1234, isoyear: 5678));
+        check("1234 5678", &[num(Year), S, num(IsoYear)], p().set_year(1234)?.set_isoyear(5678));
         check(
             "12 34 56 78",
             &[num(YearDiv100), S, num(YearMod100), S, num(IsoYearDiv100), S, num(IsoYearMod100)],
-            parsed!(year_div_100: 12, year_mod_100: 34, isoyear_div_100: 56, isoyear_mod_100: 78),
+            p().set_year_div_100(12)?
+                .set_year_mod_100(34)?
+                .set_isoyear_div_100(56)?
+                .set_isoyear_mod_100(78),
         );
         check(
             "1 2 3 45",
             &[num(Month), S, num(Day), S, num(WeekFromSun), S, num(NumDaysFromSun), num(IsoWeek)],
-            parsed!(month: 1, day: 2, week_from_sun: 3, weekday: Weekday::Thu, isoweek: 5),
+            p().set_month(1)?
+                .set_day(2)?
+                .set_week_from_sun(3)?
+                .set_weekday(Weekday::Thu)?
+                .set_isoweek(5),
         );
         check(
             "6 7 89 01",
             &[num(WeekFromMon), S, num(WeekdayFromMon), S, num(Ordinal), S, num(Hour12)],
-            parsed!(week_from_mon: 6, weekday: Weekday::Sun, ordinal: 89, hour_mod_12: 1),
+            p().set_week_from_mon(6)?.set_weekday(Weekday::Sun)?.set_ordinal(89)?.set_hour12(1),
         );
         check(
             "23 45 6 78901234 567890123",
             &[num(Hour), S, num(Minute), S, num(Second), S, num(Nanosecond), S, num(Timestamp)],
-            parsed!(hour_div_12: 1, hour_mod_12: 11, minute: 45, second: 6, nanosecond: 78_901_234, timestamp: 567_890_123),
+            p().set_ampm(true)?
+                .set_hour12(11)?
+                .set_minute(45)?
+                .set_second(6)?
+                .set_nanosecond(78_901_234)?
+                .set_timestamp(567_890_123),
         );
+
+        Ok(())
     }
 
     #[test]
-    fn test_parse_fixed() {
+    fn test_parse_fixed() -> Result<(), ParseError> {
         use crate::format::Fixed::*;
         use crate::format::Item::{Literal, Space};
 
+        let p = Parsed::new;
+
         // fixed: month and weekday names
-        check("apr", &[fixed(ShortMonthName)], parsed!(month: 4));
-        check("Apr", &[fixed(ShortMonthName)], parsed!(month: 4));
-        check("APR", &[fixed(ShortMonthName)], parsed!(month: 4));
-        check("ApR", &[fixed(ShortMonthName)], parsed!(month: 4));
+        check("apr", &[fixed(ShortMonthName)], p().set_month(4));
+        check("Apr", &[fixed(ShortMonthName)], p().set_month(4));
+        check("APR", &[fixed(ShortMonthName)], p().set_month(4));
+        check("ApR", &[fixed(ShortMonthName)], p().set_month(4));
         check("\u{0363}APR", &[fixed(ShortMonthName)], Err(INVALID));
         check("April", &[fixed(ShortMonthName)], Err(TOO_LONG)); // `Apr` is parsed
         check("A", &[fixed(ShortMonthName)], Err(TOO_SHORT));
         check("Sol", &[fixed(ShortMonthName)], Err(INVALID));
-        check("Apr", &[fixed(LongMonthName)], parsed!(month: 4));
+        check("Apr", &[fixed(LongMonthName)], p().set_month(4));
         check("Apri", &[fixed(LongMonthName)], Err(TOO_LONG)); // `Apr` is parsed
-        check("April", &[fixed(LongMonthName)], parsed!(month: 4));
+        check("April", &[fixed(LongMonthName)], p().set_month(4));
         check("Aprill", &[fixed(LongMonthName)], Err(TOO_LONG));
-        check("Aprill", &[fixed(LongMonthName), Literal("l")], parsed!(month: 4));
-        check("Aprl", &[fixed(LongMonthName), Literal("l")], parsed!(month: 4));
+        check("Aprill", &[fixed(LongMonthName), Literal("l")], p().set_month(4));
+        check("Aprl", &[fixed(LongMonthName), Literal("l")], p().set_month(4));
         check("April", &[fixed(LongMonthName), Literal("il")], Err(TOO_SHORT)); // do not backtrack
-        check("thu", &[fixed(ShortWeekdayName)], parsed!(weekday: Weekday::Thu));
-        check("Thu", &[fixed(ShortWeekdayName)], parsed!(weekday: Weekday::Thu));
-        check("THU", &[fixed(ShortWeekdayName)], parsed!(weekday: Weekday::Thu));
-        check("tHu", &[fixed(ShortWeekdayName)], parsed!(weekday: Weekday::Thu));
+        check("thu", &[fixed(ShortWeekdayName)], p().set_weekday(Weekday::Thu));
+        check("Thu", &[fixed(ShortWeekdayName)], p().set_weekday(Weekday::Thu));
+        check("THU", &[fixed(ShortWeekdayName)], p().set_weekday(Weekday::Thu));
+        check("tHu", &[fixed(ShortWeekdayName)], p().set_weekday(Weekday::Thu));
         check("Thursday", &[fixed(ShortWeekdayName)], Err(TOO_LONG)); // `Thu` is parsed
         check("T", &[fixed(ShortWeekdayName)], Err(TOO_SHORT));
         check("The", &[fixed(ShortWeekdayName)], Err(INVALID));
         check("Nop", &[fixed(ShortWeekdayName)], Err(INVALID));
-        check("Thu", &[fixed(LongWeekdayName)], parsed!(weekday: Weekday::Thu));
+        check("Thu", &[fixed(LongWeekdayName)], p().set_weekday(Weekday::Thu));
         check("Thur", &[fixed(LongWeekdayName)], Err(TOO_LONG)); // `Thu` is parsed
         check("Thurs", &[fixed(LongWeekdayName)], Err(TOO_LONG)); // `Thu` is parsed
-        check("Thursday", &[fixed(LongWeekdayName)], parsed!(weekday: Weekday::Thu));
+        check("Thursday", &[fixed(LongWeekdayName)], p().set_weekday(Weekday::Thu));
         check("Thursdays", &[fixed(LongWeekdayName)], Err(TOO_LONG));
-        check("Thursdays", &[fixed(LongWeekdayName), Literal("s")], parsed!(weekday: Weekday::Thu));
-        check("Thus", &[fixed(LongWeekdayName), Literal("s")], parsed!(weekday: Weekday::Thu));
+        check("Thursdays", &[fixed(LongWeekdayName), Literal("s")], p().set_weekday(Weekday::Thu));
+        check("Thus", &[fixed(LongWeekdayName), Literal("s")], p().set_weekday(Weekday::Thu));
         check("Thursday", &[fixed(LongWeekdayName), Literal("rsday")], Err(TOO_SHORT)); // do not backtrack
 
         // fixed: am/pm
-        check("am", &[fixed(LowerAmPm)], parsed!(hour_div_12: 0));
-        check("pm", &[fixed(LowerAmPm)], parsed!(hour_div_12: 1));
-        check("AM", &[fixed(LowerAmPm)], parsed!(hour_div_12: 0));
-        check("PM", &[fixed(LowerAmPm)], parsed!(hour_div_12: 1));
-        check("am", &[fixed(UpperAmPm)], parsed!(hour_div_12: 0));
-        check("pm", &[fixed(UpperAmPm)], parsed!(hour_div_12: 1));
-        check("AM", &[fixed(UpperAmPm)], parsed!(hour_div_12: 0));
-        check("PM", &[fixed(UpperAmPm)], parsed!(hour_div_12: 1));
-        check("Am", &[fixed(LowerAmPm)], parsed!(hour_div_12: 0));
-        check(" Am", &[Space(" "), fixed(LowerAmPm)], parsed!(hour_div_12: 0));
-        check("Am🤠", &[fixed(LowerAmPm), Literal("🤠")], parsed!(hour_div_12: 0));
-        check("🤠Am", &[Literal("🤠"), fixed(LowerAmPm)], parsed!(hour_div_12: 0));
+        check("am", &[fixed(LowerAmPm)], p().set_ampm(false));
+        check("pm", &[fixed(LowerAmPm)], p().set_ampm(true));
+        check("AM", &[fixed(LowerAmPm)], p().set_ampm(false));
+        check("PM", &[fixed(LowerAmPm)], p().set_ampm(true));
+        check("am", &[fixed(UpperAmPm)], p().set_ampm(false));
+        check("pm", &[fixed(UpperAmPm)], p().set_ampm(true));
+        check("AM", &[fixed(UpperAmPm)], p().set_ampm(false));
+        check("PM", &[fixed(UpperAmPm)], p().set_ampm(true));
+        check("Am", &[fixed(LowerAmPm)], p().set_ampm(false));
+        check(" Am", &[Space(" "), fixed(LowerAmPm)], p().set_ampm(false));
+        check("Am🤠", &[fixed(LowerAmPm), Literal("🤠")], p().set_ampm(false));
+        check("🤠Am", &[Literal("🤠"), fixed(LowerAmPm)], p().set_ampm(false));
         check("\u{0363}am", &[fixed(LowerAmPm)], Err(INVALID));
         check("\u{0360}am", &[fixed(LowerAmPm)], Err(INVALID));
         check(" Am", &[fixed(LowerAmPm)], Err(INVALID));
@@ -938,40 +947,44 @@ mod tests {
         check("x", &[fixed(LowerAmPm)], Err(TOO_SHORT));
         check("xx", &[fixed(LowerAmPm)], Err(INVALID));
         check("", &[fixed(LowerAmPm)], Err(TOO_SHORT));
+
+        Ok(())
     }
 
     #[test]
-    fn test_parse_fixed_nanosecond() {
+    fn test_parse_fixed_nanosecond() -> Result<(), ParseError> {
         use crate::format::Fixed::Nanosecond;
         use crate::format::InternalInternal::*;
         use crate::format::Item::Literal;
         use crate::format::Numeric::Second;
 
+        let p = Parsed::new;
+
         // fixed: dot plus nanoseconds
-        check("", &[fixed(Nanosecond)], parsed!()); // no field set, but not an error
+        check("", &[fixed(Nanosecond)], Ok(&mut p())); // no field set, but not an error
         check(".", &[fixed(Nanosecond)], Err(TOO_SHORT));
         check("4", &[fixed(Nanosecond)], Err(TOO_LONG)); // never consumes `4`
-        check("4", &[fixed(Nanosecond), num(Second)], parsed!(second: 4));
-        check(".0", &[fixed(Nanosecond)], parsed!(nanosecond: 0));
-        check(".4", &[fixed(Nanosecond)], parsed!(nanosecond: 400_000_000));
-        check(".42", &[fixed(Nanosecond)], parsed!(nanosecond: 420_000_000));
-        check(".421", &[fixed(Nanosecond)], parsed!(nanosecond: 421_000_000));
-        check(".42195", &[fixed(Nanosecond)], parsed!(nanosecond: 421_950_000));
-        check(".421951", &[fixed(Nanosecond)], parsed!(nanosecond: 421_951_000));
-        check(".4219512", &[fixed(Nanosecond)], parsed!(nanosecond: 421_951_200));
-        check(".42195123", &[fixed(Nanosecond)], parsed!(nanosecond: 421_951_230));
-        check(".421950803", &[fixed(Nanosecond)], parsed!(nanosecond: 421_950_803));
-        check(".4219508035", &[fixed(Nanosecond)], parsed!(nanosecond: 421_950_803));
-        check(".42195080354", &[fixed(Nanosecond)], parsed!(nanosecond: 421_950_803));
-        check(".421950803547", &[fixed(Nanosecond)], parsed!(nanosecond: 421_950_803));
-        check(".000000003", &[fixed(Nanosecond)], parsed!(nanosecond: 3));
-        check(".0000000031", &[fixed(Nanosecond)], parsed!(nanosecond: 3));
-        check(".0000000035", &[fixed(Nanosecond)], parsed!(nanosecond: 3));
-        check(".000000003547", &[fixed(Nanosecond)], parsed!(nanosecond: 3));
-        check(".0000000009", &[fixed(Nanosecond)], parsed!(nanosecond: 0));
-        check(".000000000547", &[fixed(Nanosecond)], parsed!(nanosecond: 0));
-        check(".0000000009999999999999999999999999", &[fixed(Nanosecond)], parsed!(nanosecond: 0));
-        check(".4🤠", &[fixed(Nanosecond), Literal("🤠")], parsed!(nanosecond: 400_000_000));
+        check("4", &[fixed(Nanosecond), num(Second)], p().set_second(4));
+        check(".0", &[fixed(Nanosecond)], p().set_nanosecond(0));
+        check(".4", &[fixed(Nanosecond)], p().set_nanosecond(400_000_000));
+        check(".42", &[fixed(Nanosecond)], p().set_nanosecond(420_000_000));
+        check(".421", &[fixed(Nanosecond)], p().set_nanosecond(421_000_000));
+        check(".42195", &[fixed(Nanosecond)], p().set_nanosecond(421_950_000));
+        check(".421951", &[fixed(Nanosecond)], p().set_nanosecond(421_951_000));
+        check(".4219512", &[fixed(Nanosecond)], p().set_nanosecond(421_951_200));
+        check(".42195123", &[fixed(Nanosecond)], p().set_nanosecond(421_951_230));
+        check(".421950803", &[fixed(Nanosecond)], p().set_nanosecond(421_950_803));
+        check(".4219508035", &[fixed(Nanosecond)], p().set_nanosecond(421_950_803));
+        check(".42195080354", &[fixed(Nanosecond)], p().set_nanosecond(421_950_803));
+        check(".421950803547", &[fixed(Nanosecond)], p().set_nanosecond(421_950_803));
+        check(".000000003", &[fixed(Nanosecond)], p().set_nanosecond(3));
+        check(".0000000031", &[fixed(Nanosecond)], p().set_nanosecond(3));
+        check(".0000000035", &[fixed(Nanosecond)], p().set_nanosecond(3));
+        check(".000000003547", &[fixed(Nanosecond)], p().set_nanosecond(3));
+        check(".0000000009", &[fixed(Nanosecond)], p().set_nanosecond(0));
+        check(".000000000547", &[fixed(Nanosecond)], p().set_nanosecond(0));
+        check(".0000000009999999999999999999999999", &[fixed(Nanosecond)], p().set_nanosecond(0));
+        check(".4🤠", &[fixed(Nanosecond), Literal("🤠")], p().set_nanosecond(400_000_000));
         check(".4x", &[fixed(Nanosecond)], Err(TOO_LONG));
         check(".  4", &[fixed(Nanosecond)], Err(INVALID));
         check("  .4", &[fixed(Nanosecond)], Err(TOO_LONG)); // no automatic trimming
@@ -982,22 +995,22 @@ mod tests {
         check("0", &[internal_fixed(Nanosecond3NoDot)], Err(TOO_SHORT));
         check("4", &[internal_fixed(Nanosecond3NoDot)], Err(TOO_SHORT));
         check("42", &[internal_fixed(Nanosecond3NoDot)], Err(TOO_SHORT));
-        check("421", &[internal_fixed(Nanosecond3NoDot)], parsed!(nanosecond: 421_000_000));
+        check("421", &[internal_fixed(Nanosecond3NoDot)], p().set_nanosecond(421_000_000));
         check("4210", &[internal_fixed(Nanosecond3NoDot)], Err(TOO_LONG));
         check(
             "42143",
             &[internal_fixed(Nanosecond3NoDot), num(Second)],
-            parsed!(nanosecond: 421_000_000, second: 43),
+            p().set_nanosecond(421_000_000)?.set_second(43),
         );
         check(
             "421🤠",
             &[internal_fixed(Nanosecond3NoDot), Literal("🤠")],
-            parsed!(nanosecond: 421_000_000),
+            p().set_nanosecond(421_000_000),
         );
         check(
             "🤠421",
             &[Literal("🤠"), internal_fixed(Nanosecond3NoDot)],
-            parsed!(nanosecond: 421_000_000),
+            p().set_nanosecond(421_000_000),
         );
         check("42195", &[internal_fixed(Nanosecond3NoDot)], Err(TOO_LONG));
         check("123456789", &[internal_fixed(Nanosecond3NoDot)], Err(TOO_LONG));
@@ -1010,9 +1023,9 @@ mod tests {
         check("0", &[internal_fixed(Nanosecond6NoDot)], Err(TOO_SHORT));
         check("1234", &[internal_fixed(Nanosecond6NoDot)], Err(TOO_SHORT));
         check("12345", &[internal_fixed(Nanosecond6NoDot)], Err(TOO_SHORT));
-        check("421950", &[internal_fixed(Nanosecond6NoDot)], parsed!(nanosecond: 421_950_000));
-        check("000003", &[internal_fixed(Nanosecond6NoDot)], parsed!(nanosecond: 3000));
-        check("000000", &[internal_fixed(Nanosecond6NoDot)], parsed!(nanosecond: 0));
+        check("421950", &[internal_fixed(Nanosecond6NoDot)], p().set_nanosecond(421_950_000));
+        check("000003", &[internal_fixed(Nanosecond6NoDot)], p().set_nanosecond(3000));
+        check("000000", &[internal_fixed(Nanosecond6NoDot)], p().set_nanosecond(0));
         check("1234567", &[internal_fixed(Nanosecond6NoDot)], Err(TOO_LONG));
         check("123456789", &[internal_fixed(Nanosecond6NoDot)], Err(TOO_LONG));
         check("4x", &[internal_fixed(Nanosecond6NoDot)], Err(TOO_SHORT));
@@ -1023,25 +1036,29 @@ mod tests {
         check(".", &[internal_fixed(Nanosecond9NoDot)], Err(TOO_SHORT));
         check("42195", &[internal_fixed(Nanosecond9NoDot)], Err(TOO_SHORT));
         check("12345678", &[internal_fixed(Nanosecond9NoDot)], Err(TOO_SHORT));
-        check("421950803", &[internal_fixed(Nanosecond9NoDot)], parsed!(nanosecond: 421_950_803));
-        check("000000003", &[internal_fixed(Nanosecond9NoDot)], parsed!(nanosecond: 3));
+        check("421950803", &[internal_fixed(Nanosecond9NoDot)], p().set_nanosecond(421_950_803));
+        check("000000003", &[internal_fixed(Nanosecond9NoDot)], p().set_nanosecond(3));
         check(
             "42195080354",
             &[internal_fixed(Nanosecond9NoDot), num(Second)],
-            parsed!(nanosecond: 421_950_803, second: 54),
+            p().set_nanosecond(421_950_803)?.set_second(54),
         ); // don't skip digits that come after the 9
         check("1234567890", &[internal_fixed(Nanosecond9NoDot)], Err(TOO_LONG));
-        check("000000000", &[internal_fixed(Nanosecond9NoDot)], parsed!(nanosecond: 0));
+        check("000000000", &[internal_fixed(Nanosecond9NoDot)], p().set_nanosecond(0));
         check("00000000x", &[internal_fixed(Nanosecond9NoDot)], Err(INVALID));
         check("        4", &[internal_fixed(Nanosecond9NoDot)], Err(INVALID));
         check(".42100000", &[internal_fixed(Nanosecond9NoDot)], Err(INVALID));
+
+        Ok(())
     }
 
     #[test]
-    fn test_parse_fixed_timezone_offset() {
+    fn test_parse_fixed_timezone_offset() -> Result<(), ParseError> {
         use crate::format::Fixed::*;
         use crate::format::InternalInternal::*;
         use crate::format::Item::Literal;
+
+        let p = Parsed::new;
 
         // TimezoneOffset
         check("1", &[fixed(TimezoneOffset)], Err(INVALID));
@@ -1054,16 +1071,16 @@ mod tests {
         check("+1", &[fixed(TimezoneOffset)], Err(TOO_SHORT));
         check("+12", &[fixed(TimezoneOffset)], Err(TOO_SHORT));
         check("+123", &[fixed(TimezoneOffset)], Err(TOO_SHORT));
-        check("+1234", &[fixed(TimezoneOffset)], parsed!(offset: 45_240));
+        check("+1234", &[fixed(TimezoneOffset)], p().set_offset(45_240));
         check("+12345", &[fixed(TimezoneOffset)], Err(TOO_LONG));
         check("+123456", &[fixed(TimezoneOffset)], Err(TOO_LONG));
         check("+1234567", &[fixed(TimezoneOffset)], Err(TOO_LONG));
         check("+12345678", &[fixed(TimezoneOffset)], Err(TOO_LONG));
         check("+12:", &[fixed(TimezoneOffset)], Err(TOO_SHORT));
         check("+12:3", &[fixed(TimezoneOffset)], Err(TOO_SHORT));
-        check("+12:34", &[fixed(TimezoneOffset)], parsed!(offset: 45_240));
-        check("-12:34", &[fixed(TimezoneOffset)], parsed!(offset: -45_240));
-        check("−12:34", &[fixed(TimezoneOffset)], parsed!(offset: -45_240)); // MINUS SIGN (U+2212)
+        check("+12:34", &[fixed(TimezoneOffset)], p().set_offset(45_240));
+        check("-12:34", &[fixed(TimezoneOffset)], p().set_offset(-45_240));
+        check("−12:34", &[fixed(TimezoneOffset)], p().set_offset(-45_240)); // MINUS SIGN (U+2212)
         check("+12:34:", &[fixed(TimezoneOffset)], Err(TOO_LONG));
         check("+12:34:5", &[fixed(TimezoneOffset)], Err(TOO_LONG));
         check("+12:34:56", &[fixed(TimezoneOffset)], Err(TOO_LONG));
@@ -1081,26 +1098,26 @@ mod tests {
         check("+12:3456", &[fixed(TimezoneOffset)], Err(TOO_LONG));
         check("+1234:56", &[fixed(TimezoneOffset)], Err(TOO_LONG));
         check("+1234:567", &[fixed(TimezoneOffset)], Err(TOO_LONG));
-        check("+00:00", &[fixed(TimezoneOffset)], parsed!(offset: 0));
-        check("-00:00", &[fixed(TimezoneOffset)], parsed!(offset: 0));
-        check("−00:00", &[fixed(TimezoneOffset)], parsed!(offset: 0)); // MINUS SIGN (U+2212)
-        check("+00:01", &[fixed(TimezoneOffset)], parsed!(offset: 60));
-        check("-00:01", &[fixed(TimezoneOffset)], parsed!(offset: -60));
-        check("+00:30", &[fixed(TimezoneOffset)], parsed!(offset: 1_800));
-        check("-00:30", &[fixed(TimezoneOffset)], parsed!(offset: -1_800));
-        check("+24:00", &[fixed(TimezoneOffset)], parsed!(offset: 86_400));
-        check("-24:00", &[fixed(TimezoneOffset)], parsed!(offset: -86_400));
-        check("−24:00", &[fixed(TimezoneOffset)], parsed!(offset: -86_400)); // MINUS SIGN (U+2212)
-        check("+99:59", &[fixed(TimezoneOffset)], parsed!(offset: 359_940));
-        check("-99:59", &[fixed(TimezoneOffset)], parsed!(offset: -359_940));
+        check("+00:00", &[fixed(TimezoneOffset)], p().set_offset(0));
+        check("-00:00", &[fixed(TimezoneOffset)], p().set_offset(0));
+        check("−00:00", &[fixed(TimezoneOffset)], p().set_offset(0)); // MINUS SIGN (U+2212)
+        check("+00:01", &[fixed(TimezoneOffset)], p().set_offset(60));
+        check("-00:01", &[fixed(TimezoneOffset)], p().set_offset(-60));
+        check("+00:30", &[fixed(TimezoneOffset)], p().set_offset(1800));
+        check("-00:30", &[fixed(TimezoneOffset)], p().set_offset(-1800));
+        check("+24:00", &[fixed(TimezoneOffset)], p().set_offset(86_400));
+        check("-24:00", &[fixed(TimezoneOffset)], p().set_offset(-86_400));
+        check("−24:00", &[fixed(TimezoneOffset)], p().set_offset(-86_400)); // MINUS SIGN (U+2212)
+        check("+99:59", &[fixed(TimezoneOffset)], p().set_offset(359_940));
+        check("-99:59", &[fixed(TimezoneOffset)], p().set_offset(-359_940));
         check("+00:60", &[fixed(TimezoneOffset)], Err(OUT_OF_RANGE));
         check("+00:99", &[fixed(TimezoneOffset)], Err(OUT_OF_RANGE));
         check("#12:34", &[fixed(TimezoneOffset)], Err(INVALID));
         check("+12:34 ", &[fixed(TimezoneOffset)], Err(TOO_LONG));
         check("+12 34 ", &[fixed(TimezoneOffset)], Err(INVALID));
-        check(" +12:34", &[fixed(TimezoneOffset)], parsed!(offset: 45_240));
-        check(" -12:34", &[fixed(TimezoneOffset)], parsed!(offset: -45_240));
-        check(" −12:34", &[fixed(TimezoneOffset)], parsed!(offset: -45_240)); // MINUS SIGN (U+2212)
+        check(" +12:34", &[fixed(TimezoneOffset)], p().set_offset(45_240));
+        check(" -12:34", &[fixed(TimezoneOffset)], p().set_offset(-45_240));
+        check(" −12:34", &[fixed(TimezoneOffset)], p().set_offset(-45_240)); // MINUS SIGN (U+2212)
         check("  +12:34", &[fixed(TimezoneOffset)], Err(INVALID));
         check("  -12:34", &[fixed(TimezoneOffset)], Err(INVALID));
         check("\t -12:34", &[fixed(TimezoneOffset)], Err(INVALID));
@@ -1119,14 +1136,14 @@ mod tests {
         check(
             "+12345",
             &[fixed(TimezoneOffset), num(Numeric::Day)],
-            parsed!(offset: 45_240, day: 5),
+            p().set_offset(45_240)?.set_day(5),
         );
         check(
             "+12:345",
             &[fixed(TimezoneOffset), num(Numeric::Day)],
-            parsed!(offset: 45_240, day: 5),
+            p().set_offset(45_240)?.set_day(5),
         );
-        check("+12:34:", &[fixed(TimezoneOffset), Literal(":")], parsed!(offset: 45_240));
+        check("+12:34:", &[fixed(TimezoneOffset), Literal(":")], p().set_offset(45_240));
         check("Z12:34", &[fixed(TimezoneOffset)], Err(INVALID));
         check("X12:34", &[fixed(TimezoneOffset)], Err(INVALID));
         check("Z+12:34", &[fixed(TimezoneOffset)], Err(INVALID));
@@ -1135,13 +1152,13 @@ mod tests {
         check("🤠+12:34", &[fixed(TimezoneOffset)], Err(INVALID));
         check("+12:34🤠", &[fixed(TimezoneOffset)], Err(TOO_LONG));
         check("+12:🤠34", &[fixed(TimezoneOffset)], Err(INVALID));
-        check("+1234🤠", &[fixed(TimezoneOffset), Literal("🤠")], parsed!(offset: 45_240));
-        check("-1234🤠", &[fixed(TimezoneOffset), Literal("🤠")], parsed!(offset: -45_240));
-        check("−1234🤠", &[fixed(TimezoneOffset), Literal("🤠")], parsed!(offset: -45_240)); // MINUS SIGN (U+2212)
-        check("+12:34🤠", &[fixed(TimezoneOffset), Literal("🤠")], parsed!(offset: 45_240));
-        check("-12:34🤠", &[fixed(TimezoneOffset), Literal("🤠")], parsed!(offset: -45_240));
-        check("−12:34🤠", &[fixed(TimezoneOffset), Literal("🤠")], parsed!(offset: -45_240)); // MINUS SIGN (U+2212)
-        check("🤠+12:34", &[Literal("🤠"), fixed(TimezoneOffset)], parsed!(offset: 45_240));
+        check("+1234🤠", &[fixed(TimezoneOffset), Literal("🤠")], p().set_offset(45_240));
+        check("-1234🤠", &[fixed(TimezoneOffset), Literal("🤠")], p().set_offset(-45_240));
+        check("−1234🤠", &[fixed(TimezoneOffset), Literal("🤠")], p().set_offset(-45_240)); // MINUS SIGN (U+2212)
+        check("+12:34🤠", &[fixed(TimezoneOffset), Literal("🤠")], p().set_offset(45_240));
+        check("-12:34🤠", &[fixed(TimezoneOffset), Literal("🤠")], p().set_offset(-45_240));
+        check("−12:34🤠", &[fixed(TimezoneOffset), Literal("🤠")], p().set_offset(-45_240)); // MINUS SIGN (U+2212)
+        check("🤠+12:34", &[Literal("🤠"), fixed(TimezoneOffset)], p().set_offset(45_240));
         check("Z", &[fixed(TimezoneOffset)], Err(INVALID));
         check("A", &[fixed(TimezoneOffset)], Err(INVALID));
         check("PST", &[fixed(TimezoneOffset)], Err(INVALID));
@@ -1167,9 +1184,9 @@ mod tests {
         check("+1", &[fixed(TimezoneOffsetColon)], Err(TOO_SHORT));
         check("+12", &[fixed(TimezoneOffsetColon)], Err(TOO_SHORT));
         check("+123", &[fixed(TimezoneOffsetColon)], Err(TOO_SHORT));
-        check("+1234", &[fixed(TimezoneOffsetColon)], parsed!(offset: 45_240));
-        check("-1234", &[fixed(TimezoneOffsetColon)], parsed!(offset: -45_240));
-        check("−1234", &[fixed(TimezoneOffsetColon)], parsed!(offset: -45_240)); // MINUS SIGN (U+2212)
+        check("+1234", &[fixed(TimezoneOffsetColon)], p().set_offset(45_240));
+        check("-1234", &[fixed(TimezoneOffsetColon)], p().set_offset(-45_240));
+        check("−1234", &[fixed(TimezoneOffsetColon)], p().set_offset(-45_240)); // MINUS SIGN (U+2212)
         check("+12345", &[fixed(TimezoneOffsetColon)], Err(TOO_LONG));
         check("+123456", &[fixed(TimezoneOffsetColon)], Err(TOO_LONG));
         check("+1234567", &[fixed(TimezoneOffsetColon)], Err(TOO_LONG));
@@ -1184,9 +1201,9 @@ mod tests {
         check("+1:", &[fixed(TimezoneOffsetColon)], Err(INVALID));
         check("+12:", &[fixed(TimezoneOffsetColon)], Err(TOO_SHORT));
         check("+12:3", &[fixed(TimezoneOffsetColon)], Err(TOO_SHORT));
-        check("+12:34", &[fixed(TimezoneOffsetColon)], parsed!(offset: 45_240));
-        check("-12:34", &[fixed(TimezoneOffsetColon)], parsed!(offset: -45_240));
-        check("−12:34", &[fixed(TimezoneOffsetColon)], parsed!(offset: -45_240)); // MINUS SIGN (U+2212)
+        check("+12:34", &[fixed(TimezoneOffsetColon)], p().set_offset(45_240));
+        check("-12:34", &[fixed(TimezoneOffsetColon)], p().set_offset(-45_240));
+        check("−12:34", &[fixed(TimezoneOffsetColon)], p().set_offset(-45_240)); // MINUS SIGN (U+2212)
         check("+12:34:", &[fixed(TimezoneOffsetColon)], Err(TOO_LONG));
         check("+12:34:5", &[fixed(TimezoneOffsetColon)], Err(TOO_LONG));
         check("+12:34:56", &[fixed(TimezoneOffsetColon)], Err(TOO_LONG));
@@ -1195,7 +1212,7 @@ mod tests {
         check("+12:34:56:78", &[fixed(TimezoneOffsetColon)], Err(TOO_LONG));
         check("+12:3456", &[fixed(TimezoneOffsetColon)], Err(TOO_LONG));
         check("+1234:56", &[fixed(TimezoneOffsetColon)], Err(TOO_LONG));
-        check("−12:34", &[fixed(TimezoneOffsetColon)], parsed!(offset: -45_240)); // MINUS SIGN (U+2212)
+        check("−12:34", &[fixed(TimezoneOffsetColon)], p().set_offset(-45_240)); // MINUS SIGN (U+2212)
         check("−12 : 34", &[fixed(TimezoneOffsetColon)], Err(INVALID)); // MINUS SIGN (U+2212)
         check("+12 :34", &[fixed(TimezoneOffsetColon)], Err(INVALID));
         check("+12: 34", &[fixed(TimezoneOffsetColon)], Err(INVALID));
@@ -1215,8 +1232,8 @@ mod tests {
         check("#1234", &[fixed(TimezoneOffsetColon)], Err(INVALID));
         check("#12:34", &[fixed(TimezoneOffsetColon)], Err(INVALID));
         check("+12:34 ", &[fixed(TimezoneOffsetColon)], Err(TOO_LONG));
-        check(" +12:34", &[fixed(TimezoneOffsetColon)], parsed!(offset: 45_240));
-        check("\t+12:34", &[fixed(TimezoneOffsetColon)], parsed!(offset: 45_240));
+        check(" +12:34", &[fixed(TimezoneOffsetColon)], p().set_offset(45_240));
+        check("\t+12:34", &[fixed(TimezoneOffsetColon)], p().set_offset(45_240));
         check("\t\t+12:34", &[fixed(TimezoneOffsetColon)], Err(INVALID));
         check("12:34 ", &[fixed(TimezoneOffsetColon)], Err(INVALID));
         check(" 12:34", &[fixed(TimezoneOffsetColon)], Err(INVALID));
@@ -1226,14 +1243,14 @@ mod tests {
         check(
             "+12345",
             &[fixed(TimezoneOffsetColon), num(Numeric::Day)],
-            parsed!(offset: 45_240, day: 5),
+            p().set_offset(45_240)?.set_day(5),
         );
         check(
             "+12:345",
             &[fixed(TimezoneOffsetColon), num(Numeric::Day)],
-            parsed!(offset: 45_240, day: 5),
+            p().set_offset(45_240)?.set_day(5),
         );
-        check("+12:34:", &[fixed(TimezoneOffsetColon), Literal(":")], parsed!(offset: 45_240));
+        check("+12:34:", &[fixed(TimezoneOffsetColon), Literal(":")], p().set_offset(45_240));
         check("Z", &[fixed(TimezoneOffsetColon)], Err(INVALID));
         check("A", &[fixed(TimezoneOffsetColon)], Err(INVALID));
         check("PST", &[fixed(TimezoneOffsetColon)], Err(INVALID));
@@ -1263,9 +1280,9 @@ mod tests {
         check("+1", &[fixed(TimezoneOffsetZ)], Err(TOO_SHORT));
         check("+12", &[fixed(TimezoneOffsetZ)], Err(TOO_SHORT));
         check("+123", &[fixed(TimezoneOffsetZ)], Err(TOO_SHORT));
-        check("+1234", &[fixed(TimezoneOffsetZ)], parsed!(offset: 45_240));
-        check("-1234", &[fixed(TimezoneOffsetZ)], parsed!(offset: -45_240));
-        check("−1234", &[fixed(TimezoneOffsetZ)], parsed!(offset: -45_240)); // MINUS SIGN (U+2212)
+        check("+1234", &[fixed(TimezoneOffsetZ)], p().set_offset(45_240));
+        check("-1234", &[fixed(TimezoneOffsetZ)], p().set_offset(-45_240));
+        check("−1234", &[fixed(TimezoneOffsetZ)], p().set_offset(-45_240)); // MINUS SIGN (U+2212)
         check("+12345", &[fixed(TimezoneOffsetZ)], Err(TOO_LONG));
         check("+123456", &[fixed(TimezoneOffsetZ)], Err(TOO_LONG));
         check("+1234567", &[fixed(TimezoneOffsetZ)], Err(TOO_LONG));
@@ -1280,9 +1297,9 @@ mod tests {
         check("+1:", &[fixed(TimezoneOffsetZ)], Err(INVALID));
         check("+12:", &[fixed(TimezoneOffsetZ)], Err(TOO_SHORT));
         check("+12:3", &[fixed(TimezoneOffsetZ)], Err(TOO_SHORT));
-        check("+12:34", &[fixed(TimezoneOffsetZ)], parsed!(offset: 45_240));
-        check("-12:34", &[fixed(TimezoneOffsetZ)], parsed!(offset: -45_240));
-        check("−12:34", &[fixed(TimezoneOffsetZ)], parsed!(offset: -45_240)); // MINUS SIGN (U+2212)
+        check("+12:34", &[fixed(TimezoneOffsetZ)], p().set_offset(45_240));
+        check("-12:34", &[fixed(TimezoneOffsetZ)], p().set_offset(-45_240));
+        check("−12:34", &[fixed(TimezoneOffsetZ)], p().set_offset(-45_240)); // MINUS SIGN (U+2212)
         check("+12:34:", &[fixed(TimezoneOffsetZ)], Err(TOO_LONG));
         check("+12:34:5", &[fixed(TimezoneOffsetZ)], Err(TOO_LONG));
         check("+12:34:56", &[fixed(TimezoneOffsetZ)], Err(TOO_LONG));
@@ -1304,24 +1321,24 @@ mod tests {
         check(" 12:34", &[fixed(TimezoneOffsetZ)], Err(INVALID));
         check("+12:34 ", &[fixed(TimezoneOffsetZ)], Err(TOO_LONG));
         check("+12 34 ", &[fixed(TimezoneOffsetZ)], Err(INVALID));
-        check(" +12:34", &[fixed(TimezoneOffsetZ)], parsed!(offset: 45_240));
+        check(" +12:34", &[fixed(TimezoneOffsetZ)], p().set_offset(45_240));
         check(
             "+12345",
             &[fixed(TimezoneOffsetZ), num(Numeric::Day)],
-            parsed!(offset: 45_240, day: 5),
+            p().set_offset(45_240)?.set_day(5),
         );
         check(
             "+12:345",
             &[fixed(TimezoneOffsetZ), num(Numeric::Day)],
-            parsed!(offset: 45_240, day: 5),
+            p().set_offset(45_240)?.set_day(5),
         );
-        check("+12:34:", &[fixed(TimezoneOffsetZ), Literal(":")], parsed!(offset: 45_240));
+        check("+12:34:", &[fixed(TimezoneOffsetZ), Literal(":")], p().set_offset(45_240));
         check("Z12:34", &[fixed(TimezoneOffsetZ)], Err(TOO_LONG));
         check("X12:34", &[fixed(TimezoneOffsetZ)], Err(INVALID));
-        check("Z", &[fixed(TimezoneOffsetZ)], parsed!(offset: 0));
-        check("z", &[fixed(TimezoneOffsetZ)], parsed!(offset: 0));
-        check(" Z", &[fixed(TimezoneOffsetZ)], parsed!(offset: 0));
-        check(" z", &[fixed(TimezoneOffsetZ)], parsed!(offset: 0));
+        check("Z", &[fixed(TimezoneOffsetZ)], p().set_offset(0));
+        check("z", &[fixed(TimezoneOffsetZ)], p().set_offset(0));
+        check(" Z", &[fixed(TimezoneOffsetZ)], p().set_offset(0));
+        check(" z", &[fixed(TimezoneOffsetZ)], p().set_offset(0));
         check("\u{0363}Z", &[fixed(TimezoneOffsetZ)], Err(INVALID));
         check("Z ", &[fixed(TimezoneOffsetZ)], Err(TOO_LONG));
         check("A", &[fixed(TimezoneOffsetZ)], Err(INVALID));
@@ -1339,10 +1356,10 @@ mod tests {
         check(" -Z", &[fixed(TimezoneOffsetZ)], Err(TOO_SHORT));
         check("+:Z", &[fixed(TimezoneOffsetZ)], Err(INVALID));
         check("Y", &[fixed(TimezoneOffsetZ)], Err(INVALID));
-        check("Zulu", &[fixed(TimezoneOffsetZ), Literal("ulu")], parsed!(offset: 0));
-        check("zulu", &[fixed(TimezoneOffsetZ), Literal("ulu")], parsed!(offset: 0));
-        check("+1234ulu", &[fixed(TimezoneOffsetZ), Literal("ulu")], parsed!(offset: 45_240));
-        check("+12:34ulu", &[fixed(TimezoneOffsetZ), Literal("ulu")], parsed!(offset: 45_240));
+        check("Zulu", &[fixed(TimezoneOffsetZ), Literal("ulu")], p().set_offset(0));
+        check("zulu", &[fixed(TimezoneOffsetZ), Literal("ulu")], p().set_offset(0));
+        check("+1234ulu", &[fixed(TimezoneOffsetZ), Literal("ulu")], p().set_offset(45_240));
+        check("+12:34ulu", &[fixed(TimezoneOffsetZ), Literal("ulu")], p().set_offset(45_240));
         // Testing `TimezoneOffsetZ` also tests same path as `TimezoneOffsetColonZ`
         // in function `parse_internal`.
         // No need for separate tests for `TimezoneOffsetColonZ`.
@@ -1357,11 +1374,11 @@ mod tests {
         check("1234567", &[internal_fixed(TimezoneOffsetPermissive)], Err(INVALID));
         check("12345678", &[internal_fixed(TimezoneOffsetPermissive)], Err(INVALID));
         check("+1", &[internal_fixed(TimezoneOffsetPermissive)], Err(TOO_SHORT));
-        check("+12", &[internal_fixed(TimezoneOffsetPermissive)], parsed!(offset: 43_200));
+        check("+12", &[internal_fixed(TimezoneOffsetPermissive)], p().set_offset(43_200));
         check("+123", &[internal_fixed(TimezoneOffsetPermissive)], Err(TOO_SHORT));
-        check("+1234", &[internal_fixed(TimezoneOffsetPermissive)], parsed!(offset: 45_240));
-        check("-1234", &[internal_fixed(TimezoneOffsetPermissive)], parsed!(offset: -45_240));
-        check("−1234", &[internal_fixed(TimezoneOffsetPermissive)], parsed!(offset: -45_240)); // MINUS SIGN (U+2212)
+        check("+1234", &[internal_fixed(TimezoneOffsetPermissive)], p().set_offset(45_240));
+        check("-1234", &[internal_fixed(TimezoneOffsetPermissive)], p().set_offset(-45_240));
+        check("−1234", &[internal_fixed(TimezoneOffsetPermissive)], p().set_offset(-45_240)); // MINUS SIGN (U+2212)
         check("+12345", &[internal_fixed(TimezoneOffsetPermissive)], Err(TOO_LONG));
         check("+123456", &[internal_fixed(TimezoneOffsetPermissive)], Err(TOO_LONG));
         check("+1234567", &[internal_fixed(TimezoneOffsetPermissive)], Err(TOO_LONG));
@@ -1374,11 +1391,11 @@ mod tests {
         check("12:34:5", &[internal_fixed(TimezoneOffsetPermissive)], Err(INVALID));
         check("12:34:56", &[internal_fixed(TimezoneOffsetPermissive)], Err(INVALID));
         check("+1:", &[internal_fixed(TimezoneOffsetPermissive)], Err(INVALID));
-        check("+12:", &[internal_fixed(TimezoneOffsetPermissive)], parsed!(offset: 43_200));
+        check("+12:", &[internal_fixed(TimezoneOffsetPermissive)], p().set_offset(43_200));
         check("+12:3", &[internal_fixed(TimezoneOffsetPermissive)], Err(TOO_SHORT));
-        check("+12:34", &[internal_fixed(TimezoneOffsetPermissive)], parsed!(offset: 45_240));
-        check("-12:34", &[internal_fixed(TimezoneOffsetPermissive)], parsed!(offset: -45_240));
-        check("−12:34", &[internal_fixed(TimezoneOffsetPermissive)], parsed!(offset: -45_240)); // MINUS SIGN (U+2212)
+        check("+12:34", &[internal_fixed(TimezoneOffsetPermissive)], p().set_offset(45_240));
+        check("-12:34", &[internal_fixed(TimezoneOffsetPermissive)], p().set_offset(-45_240));
+        check("−12:34", &[internal_fixed(TimezoneOffsetPermissive)], p().set_offset(-45_240)); // MINUS SIGN (U+2212)
         check("+12:34:", &[internal_fixed(TimezoneOffsetPermissive)], Err(TOO_LONG));
         check("+12:34:5", &[internal_fixed(TimezoneOffsetPermissive)], Err(TOO_LONG));
         check("+12:34:56", &[internal_fixed(TimezoneOffsetPermissive)], Err(TOO_LONG));
@@ -1405,23 +1422,23 @@ mod tests {
         check("12:34 ", &[internal_fixed(TimezoneOffsetPermissive)], Err(INVALID));
         check(" 12:34", &[internal_fixed(TimezoneOffsetPermissive)], Err(INVALID));
         check("+12:34 ", &[internal_fixed(TimezoneOffsetPermissive)], Err(TOO_LONG));
-        check(" +12:34", &[internal_fixed(TimezoneOffsetPermissive)], parsed!(offset: 45_240));
-        check(" -12:34", &[internal_fixed(TimezoneOffsetPermissive)], parsed!(offset: -45_240));
-        check(" −12:34", &[internal_fixed(TimezoneOffsetPermissive)], parsed!(offset: -45_240)); // MINUS SIGN (U+2212)
+        check(" +12:34", &[internal_fixed(TimezoneOffsetPermissive)], p().set_offset(45_240));
+        check(" -12:34", &[internal_fixed(TimezoneOffsetPermissive)], p().set_offset(-45_240));
+        check(" −12:34", &[internal_fixed(TimezoneOffsetPermissive)], p().set_offset(-45_240)); // MINUS SIGN (U+2212)
         check(
             "+12345",
             &[internal_fixed(TimezoneOffsetPermissive), num(Numeric::Day)],
-            parsed!(offset: 45_240, day: 5),
+            p().set_offset(45_240)?.set_day(5),
         );
         check(
             "+12:345",
             &[internal_fixed(TimezoneOffsetPermissive), num(Numeric::Day)],
-            parsed!(offset: 45_240, day: 5),
+            p().set_offset(45_240)?.set_day(5),
         );
         check(
             "+12:34:",
             &[internal_fixed(TimezoneOffsetPermissive), Literal(":")],
-            parsed!(offset: 45_240),
+            p().set_offset(45_240),
         );
         check("🤠+12:34", &[internal_fixed(TimezoneOffsetPermissive)], Err(INVALID));
         check("+12:34🤠", &[internal_fixed(TimezoneOffsetPermissive)], Err(TOO_LONG));
@@ -1429,19 +1446,19 @@ mod tests {
         check(
             "+12:34🤠",
             &[internal_fixed(TimezoneOffsetPermissive), Literal("🤠")],
-            parsed!(offset: 45_240),
+            p().set_offset(45_240),
         );
         check(
             "🤠+12:34",
             &[Literal("🤠"), internal_fixed(TimezoneOffsetPermissive)],
-            parsed!(offset: 45_240),
+            p().set_offset(45_240),
         );
-        check("Z", &[internal_fixed(TimezoneOffsetPermissive)], parsed!(offset: 0));
+        check("Z", &[internal_fixed(TimezoneOffsetPermissive)], p().set_offset(0));
         check("A", &[internal_fixed(TimezoneOffsetPermissive)], Err(INVALID));
         check("PST", &[internal_fixed(TimezoneOffsetPermissive)], Err(INVALID));
-        check("z", &[internal_fixed(TimezoneOffsetPermissive)], parsed!(offset: 0));
-        check(" Z", &[internal_fixed(TimezoneOffsetPermissive)], parsed!(offset: 0));
-        check(" z", &[internal_fixed(TimezoneOffsetPermissive)], parsed!(offset: 0));
+        check("z", &[internal_fixed(TimezoneOffsetPermissive)], p().set_offset(0));
+        check(" Z", &[internal_fixed(TimezoneOffsetPermissive)], p().set_offset(0));
+        check(" z", &[internal_fixed(TimezoneOffsetPermissive)], p().set_offset(0));
         check("Z ", &[internal_fixed(TimezoneOffsetPermissive)], Err(TOO_LONG));
         check("#Z", &[internal_fixed(TimezoneOffsetPermissive)], Err(INVALID));
         check(":Z", &[internal_fixed(TimezoneOffsetPermissive)], Err(INVALID));
@@ -1459,22 +1476,26 @@ mod tests {
         check("Y", &[internal_fixed(TimezoneOffsetPermissive)], Err(INVALID));
 
         // TimezoneName
-        check("CEST", &[fixed(TimezoneName)], parsed!());
-        check("cest", &[fixed(TimezoneName)], parsed!()); // lowercase
-        check("XXXXXXXX", &[fixed(TimezoneName)], parsed!()); // not a real timezone name
-        check("!!!!", &[fixed(TimezoneName)], parsed!()); // not a real timezone name!
-        check("CEST 5", &[fixed(TimezoneName), Literal(" "), num(Numeric::Day)], parsed!(day: 5));
+        check("CEST", &[fixed(TimezoneName)], Ok(&mut p()));
+        check("cest", &[fixed(TimezoneName)], Ok(&mut p())); // lowercase
+        check("XXXXXXXX", &[fixed(TimezoneName)], Ok(&mut p())); // not a real timezone name
+        check("!!!!", &[fixed(TimezoneName)], Ok(&mut p())); // not a real timezone name!
+        check("CEST 5", &[fixed(TimezoneName), Literal(" "), num(Numeric::Day)], p().set_day(5));
         check("CEST ", &[fixed(TimezoneName)], Err(TOO_LONG));
         check(" CEST", &[fixed(TimezoneName)], Err(TOO_LONG));
         check("CE ST", &[fixed(TimezoneName)], Err(TOO_LONG));
+
+        Ok(())
     }
 
     #[test]
     #[rustfmt::skip]
-    fn test_parse_practical_examples() {
+    fn test_parse_practical_examples() -> Result<(), ParseError> {
         use crate::format::InternalInternal::*;
         use crate::format::Item::{Literal, Space};
         use crate::format::Numeric::*;
+
+        let p = Parsed::new;
 
         // some practical examples
         check(
@@ -1484,10 +1505,7 @@ mod tests {
                 num(Hour), Literal(":"), num(Minute), Literal(":"), num(Second),
                 fixed(Fixed::TimezoneOffset),
             ],
-            parsed!(
-                year: 2015, month: 2, day: 4, hour_div_12: 1, hour_mod_12: 2, minute: 37,
-                second: 5, offset: 32400
-            ),
+            p().set_year(2015)?.set_month(2)?.set_day(4)?.set_hour(14)?.set_minute(37)?.set_second(5)?.set_offset(32_400),
         );
         check(
             "2015-02-04T14:37:05-09:00",
@@ -1496,10 +1514,7 @@ mod tests {
                 num(Hour), Literal(":"), num(Minute), Literal(":"), num(Second),
                 fixed(Fixed::TimezoneOffset),
             ],
-            parsed!(
-                year: 2015, month: 2, day: 4, hour_div_12: 1, hour_mod_12: 2, minute: 37,
-                second: 5, offset: -32400
-            ),
+            p().set_year(2015)?.set_month(2)?.set_day(4)?.set_hour(14)?.set_minute(37)?.set_second(5)?.set_offset(-32_400),
         );
         check(
             "2015-02-04T14:37:05−09:00", // timezone offset using MINUS SIGN (U+2212)
@@ -1508,10 +1523,7 @@ mod tests {
                 num(Hour), Literal(":"), num(Minute), Literal(":"), num(Second),
                 fixed(Fixed::TimezoneOffset)
             ],
-            parsed!(
-                year: 2015, month: 2, day: 4, hour_div_12: 1, hour_mod_12: 2, minute: 37,
-                second: 5, offset: -32400
-            ),
+            p().set_year(2015)?.set_month(2)?.set_day(4)?.set_hour(14)?.set_minute(37)?.set_second(5)?.set_offset(-32_400),
         );
         check(
             "20150204143705567",
@@ -1519,10 +1531,7 @@ mod tests {
                 num(Year), num(Month), num(Day), num(Hour), num(Minute), num(Second),
                 internal_fixed(Nanosecond3NoDot)
             ],
-            parsed!(
-                year: 2015, month: 2, day: 4, hour_div_12: 1, hour_mod_12: 2, minute: 37,
-                second: 5, nanosecond: 567000000
-            ),
+            p().set_year(2015)?.set_month(2)?.set_day(4)?.set_hour(14)?.set_minute(37)?.set_second(5)?.set_nanosecond(567_000_000),
         );
         check(
             "Mon, 10 Jun 2013 09:32:37 GMT",
@@ -1531,10 +1540,7 @@ mod tests {
                 fixed(Fixed::ShortMonthName), Space(" "), num(Year), Space(" "), num(Hour),
                 Literal(":"), num(Minute), Literal(":"), num(Second), Space(" "), Literal("GMT")
             ],
-            parsed!(
-                year: 2013, month: 6, day: 10, weekday: Weekday::Mon,
-                hour_div_12: 0, hour_mod_12: 9, minute: 32, second: 37
-            ),
+            p().set_year(2013)?.set_month(6)?.set_day(10)?.set_weekday(Weekday::Mon)?.set_hour(9)?.set_minute(32)?.set_second(37),
         );
         check(
             "🤠Mon, 10 Jun🤠2013 09:32:37  GMT🤠",
@@ -1544,10 +1550,7 @@ mod tests {
                 num(Hour), Literal(":"), num(Minute), Literal(":"), num(Second), Space("  "),
                 Literal("GMT"), Literal("🤠")
             ],
-            parsed!(
-                year: 2013, month: 6, day: 10, weekday: Weekday::Mon,
-                hour_div_12: 0, hour_mod_12: 9, minute: 32, second: 37
-            ),
+            p().set_year(2013)?.set_month(6)?.set_day(10)?.set_weekday(Weekday::Mon)?.set_hour(9)?.set_minute(32)?.set_second(37),
         );
         check(
             "Sun Aug 02 13:39:15 CEST 2020",
@@ -1557,32 +1560,27 @@ mod tests {
                 Literal(":"), num(Second), Space(" "), fixed(Fixed::TimezoneName), Space(" "),
                 num(Year)
             ],
-            parsed!(
-                year: 2020, month: 8, day: 2, weekday: Weekday::Sun,
-                hour_div_12: 1, hour_mod_12: 1, minute: 39, second: 15
-            ),
+            p().set_year(2020)?.set_month(8)?.set_day(2)?.set_weekday(Weekday::Sun)?.set_hour(13)?.set_minute(39)?.set_second(15),
         );
         check(
             "20060102150405",
             &[num(Year), num(Month), num(Day), num(Hour), num(Minute), num(Second)],
-            parsed!(
-                year: 2006, month: 1, day: 2, hour_div_12: 1, hour_mod_12: 3, minute: 4, second: 5
-            ),
+            p().set_year(2006)?.set_month(1)?.set_day(2)?.set_hour(15)?.set_minute(4)?.set_second(5),
         );
         check(
             "3:14PM",
             &[num(Hour12), Literal(":"), num(Minute), fixed(Fixed::LowerAmPm)],
-            parsed!(hour_div_12: 1, hour_mod_12: 3, minute: 14),
+            p().set_ampm(true)?.set_hour12(3)?.set_minute(14),
         );
         check(
             "12345678901234.56789",
             &[num(Timestamp), Literal("."), num(Nanosecond)],
-            parsed!(nanosecond: 56_789, timestamp: 12_345_678_901_234),
+            p().set_nanosecond(56_789)?.set_timestamp(12_345_678_901_234),
         );
         check(
             "12345678901234.56789",
             &[num(Timestamp), fixed(Fixed::Nanosecond)],
-            parsed!(nanosecond: 567_890_000, timestamp: 12_345_678_901_234),
+            p().set_nanosecond(567_890_000)?.set_timestamp(12_345_678_901_234),
         );
 
         // docstring examples from `impl str::FromStr`
@@ -1593,10 +1591,7 @@ mod tests {
                 num(Hour), Literal(":"), num(Minute), Literal(":"), num(Second),
                 internal_fixed(TimezoneOffsetPermissive)
             ],
-            parsed!(
-                year: 2000, month: 1, day: 2, hour_div_12: 0, hour_mod_12: 3, minute: 4, second: 5,
-                offset: 0
-            ),
+            p().set_year(2000)?.set_month(1)?.set_day(2)?.set_hour(3)?.set_minute(4)?.set_second(5)?.set_offset(0),
         );
         check(
             "2000-01-02 03:04:05Z",
@@ -1605,11 +1600,10 @@ mod tests {
                 num(Hour), Literal(":"), num(Minute), Literal(":"), num(Second),
                 internal_fixed(TimezoneOffsetPermissive)
             ],
-            parsed!(
-                year: 2000, month: 1, day: 2, hour_div_12: 0, hour_mod_12: 3, minute: 4, second: 5,
-                offset: 0
-            ),
+            p().set_year(2000)?.set_month(1)?.set_day(2)?.set_hour(3)?.set_minute(4)?.set_second(5)?.set_offset(0),
         );
+
+        Ok(())
     }
 
     #[track_caller]
@@ -1619,11 +1613,11 @@ mod tests {
     }
 
     #[track_caller]
-    fn check(s: &str, items: &[Item], expected: ParseResult<Parsed>) {
+    fn check(s: &str, items: &[Item], expected: ParseResult<&mut Parsed>) {
         let mut parsed = Parsed::new();
         let result = parse(&mut parsed, s, items.iter());
         let parsed = result.map(|_| parsed);
-        assert_eq!(parsed, expected);
+        assert_eq!(parsed.as_ref(), expected.as_deref());
     }
 
     #[test]

--- a/src/format/parse.rs
+++ b/src/format/parse.rs
@@ -14,7 +14,7 @@ use super::{ParseError, ParseErrorKind, ParseResult};
 use super::{BAD_FORMAT, INVALID, NOT_ENOUGH, OUT_OF_RANGE, TOO_LONG, TOO_SHORT};
 use crate::{DateTime, FixedOffset, Weekday};
 
-fn set_weekday_with_num_days_from_sunday(p: &mut Parsed, v: i64) -> ParseResult<()> {
+fn set_weekday_with_num_days_from_sunday(p: &mut Parsed, v: i64) -> ParseResult<&mut Parsed> {
     p.set_weekday(match v {
         0 => Weekday::Sun,
         1 => Weekday::Mon,
@@ -27,7 +27,7 @@ fn set_weekday_with_num_days_from_sunday(p: &mut Parsed, v: i64) -> ParseResult<
     })
 }
 
-fn set_weekday_with_number_from_monday(p: &mut Parsed, v: i64) -> ParseResult<()> {
+fn set_weekday_with_number_from_monday(p: &mut Parsed, v: i64) -> ParseResult<&mut Parsed> {
     p.set_weekday(match v {
         1 => Weekday::Mon,
         2 => Weekday::Tue,
@@ -361,7 +361,7 @@ where
 
             Item::Numeric(ref spec, ref _pad) => {
                 use super::Numeric::*;
-                type Setter = fn(&mut Parsed, i64) -> ParseResult<()>;
+                type Setter = fn(&mut Parsed, i64) -> ParseResult<&mut Parsed>;
 
                 let (width, signed, set): (usize, bool, Setter) = match *spec {
                     Year => (4, true, Parsed::set_year),

--- a/src/format/parsed.rs
+++ b/src/format/parsed.rs
@@ -1123,37 +1123,18 @@ mod tests {
             Err(OUT_OF_RANGE)
         );
         assert_eq!(
-            parse!(year_div_100: 19, year_mod_100: 83, month: 13, day: 1),
-            Err(OUT_OF_RANGE)
-        );
-        assert_eq!(
             parse!(year_div_100: 19, year_mod_100: 83, month: 12, day: 31),
             ymd(1983, 12, 31)
         );
-        assert_eq!(
-            parse!(year_div_100: 19, year_mod_100: 83, month: 12, day: 32),
-            Err(OUT_OF_RANGE)
-        );
-        assert_eq!(
-            parse!(year_div_100: 19, year_mod_100: 83, month: 12, day: 0),
-            Err(OUT_OF_RANGE)
-        );
-        assert_eq!(
-            parse!(year_div_100: 19, year_mod_100: 100, month: 1, day: 1),
-            Err(OUT_OF_RANGE)
-        );
-        assert_eq!(parse!(year_div_100: 19, year_mod_100: -1, month: 1, day: 1), Err(OUT_OF_RANGE));
         assert_eq!(parse!(year_div_100: 0, year_mod_100: 0, month: 1, day: 1), ymd(0, 1, 1));
-        assert_eq!(parse!(year_div_100: -1, year_mod_100: 42, month: 1, day: 1), Err(OUT_OF_RANGE));
         let max_year = NaiveDate::MAX.year();
         assert_eq!(
-            parse!(year_div_100: max_year / 100,
-                          year_mod_100: max_year % 100, month: 1, day: 1),
+            parse!(year_div_100: max_year / 100, year_mod_100: max_year % 100, month: 1, day: 1),
             ymd(max_year, 1, 1)
         );
         assert_eq!(
             parse!(year_div_100: (max_year + 1) / 100,
-                          year_mod_100: (max_year + 1) % 100, month: 1, day: 1),
+                   year_mod_100: (max_year + 1) % 100, month: 1, day: 1),
             Err(OUT_OF_RANGE)
         );
 
@@ -1170,20 +1151,8 @@ mod tests {
             parse!(year: 1984, year_div_100: 18, year_mod_100: 94, month: 1, day: 1),
             Err(IMPOSSIBLE)
         );
-        assert_eq!(
-            parse!(year: 1984, year_div_100: 18, year_mod_100: 184, month: 1, day: 1),
-            Err(OUT_OF_RANGE)
-        );
-        assert_eq!(
-            parse!(year: -1, year_div_100: 0, year_mod_100: -1, month: 1, day: 1),
-            Err(OUT_OF_RANGE)
-        );
-        assert_eq!(
-            parse!(year: -1, year_div_100: -1, year_mod_100: 99, month: 1, day: 1),
-            Err(OUT_OF_RANGE)
-        );
-        assert_eq!(parse!(year: -1, year_div_100: 0, month: 1, day: 1), Err(OUT_OF_RANGE));
-        assert_eq!(parse!(year: -1, year_mod_100: 99, month: 1, day: 1), Err(OUT_OF_RANGE));
+        assert_eq!(parse!(year: -1, year_div_100: 0, month: 1, day: 1), Err(IMPOSSIBLE));
+        assert_eq!(parse!(year: -1, year_mod_100: 99, month: 1, day: 1), Err(IMPOSSIBLE));
 
         // weekdates
         assert_eq!(parse!(year: 2000, week_from_mon: 0), Err(NOT_ENOUGH));
@@ -1256,22 +1225,21 @@ mod tests {
         // more complex cases
         assert_eq!(
             parse!(year: 2014, month: 12, day: 31, ordinal: 365, isoyear: 2015, isoweek: 1,
-                          week_from_sun: 52, week_from_mon: 52, weekday: Wed),
+                   week_from_sun: 52, week_from_mon: 52, weekday: Wed),
             ymd(2014, 12, 31)
         );
         assert_eq!(
             parse!(year: 2014, month: 12, ordinal: 365, isoyear: 2015, isoweek: 1,
-                          week_from_sun: 52, week_from_mon: 52),
+                   week_from_sun: 52, week_from_mon: 52),
             ymd(2014, 12, 31)
         );
         assert_eq!(
             parse!(year: 2014, month: 12, day: 31, ordinal: 365, isoyear: 2014, isoweek: 53,
-                          week_from_sun: 52, week_from_mon: 52, weekday: Wed),
+                   week_from_sun: 52, week_from_mon: 52, weekday: Wed),
             Err(IMPOSSIBLE)
         ); // no ISO week date 2014-W53-3
         assert_eq!(
-            parse!(year: 2012, isoyear: 2015, isoweek: 1,
-                          week_from_sun: 52, week_from_mon: 52),
+            parse!(year: 2012, isoyear: 2015, isoweek: 1, week_from_sun: 52, week_from_mon: 52),
             Err(NOT_ENOUGH)
         ); // ambiguous (2014-12-29, 2014-12-30, 2014-12-31)
         assert_eq!(parse!(year_div_100: 20, isoyear_mod_100: 15, ordinal: 366), Err(NOT_ENOUGH));
@@ -1305,20 +1273,6 @@ mod tests {
         assert_eq!(
             parse!(hour_div_12: 0, hour_mod_12: 1, minute: 23, nanosecond: 456_789_012),
             Err(NOT_ENOUGH)
-        );
-
-        // out-of-range conditions
-        assert_eq!(parse!(hour_div_12: 2, hour_mod_12: 0, minute: 0), Err(OUT_OF_RANGE));
-        assert_eq!(parse!(hour_div_12: 1, hour_mod_12: 12, minute: 0), Err(OUT_OF_RANGE));
-        assert_eq!(parse!(hour_div_12: 0, hour_mod_12: 1, minute: 60), Err(OUT_OF_RANGE));
-        assert_eq!(
-            parse!(hour_div_12: 0, hour_mod_12: 1, minute: 23, second: 61),
-            Err(OUT_OF_RANGE)
-        );
-        assert_eq!(
-            parse!(hour_div_12: 0, hour_mod_12: 1, minute: 23, second: 34,
-                          nanosecond: 1_000_000_000),
-            Err(OUT_OF_RANGE)
         );
 
         // leap seconds
@@ -1440,51 +1394,44 @@ mod tests {
         // we need to have separate tests for them since it uses another control flow.
         assert_eq!(
             parse!(year: 2012, ordinal: 182, hour_div_12: 1, hour_mod_12: 11,
-                          minute: 59, second: 59, timestamp: 1_341_100_798),
+                   minute: 59, second: 59, timestamp: 1_341_100_798),
             Err(IMPOSSIBLE)
         );
         assert_eq!(
             parse!(year: 2012, ordinal: 182, hour_div_12: 1, hour_mod_12: 11,
-                          minute: 59, second: 59, timestamp: 1_341_100_799),
+                   minute: 59, second: 59, timestamp: 1_341_100_799),
             ymdhms(2012, 6, 30, 23, 59, 59)
         );
         assert_eq!(
             parse!(year: 2012, ordinal: 182, hour_div_12: 1, hour_mod_12: 11,
-                          minute: 59, second: 59, timestamp: 1_341_100_800),
+                   minute: 59, second: 59, timestamp: 1_341_100_800),
             Err(IMPOSSIBLE)
         );
         assert_eq!(
             parse!(year: 2012, ordinal: 182, hour_div_12: 1, hour_mod_12: 11,
-                          minute: 59, second: 60, timestamp: 1_341_100_799),
+                   minute: 59, second: 60, timestamp: 1_341_100_799),
             ymdhmsn(2012, 6, 30, 23, 59, 59, 1_000_000_000)
         );
         assert_eq!(
             parse!(year: 2012, ordinal: 182, hour_div_12: 1, hour_mod_12: 11,
-                          minute: 59, second: 60, timestamp: 1_341_100_800),
+                   minute: 59, second: 60, timestamp: 1_341_100_800),
             ymdhmsn(2012, 6, 30, 23, 59, 59, 1_000_000_000)
         );
         assert_eq!(
             parse!(year: 2012, ordinal: 183, hour_div_12: 0, hour_mod_12: 0,
-                          minute: 0, second: 0, timestamp: 1_341_100_800),
+                   minute: 0, second: 0, timestamp: 1_341_100_800),
             ymdhms(2012, 7, 1, 0, 0, 0)
         );
         assert_eq!(
             parse!(year: 2012, ordinal: 183, hour_div_12: 0, hour_mod_12: 0,
-                          minute: 0, second: 1, timestamp: 1_341_100_800),
+                   minute: 0, second: 1, timestamp: 1_341_100_800),
             Err(IMPOSSIBLE)
         );
         assert_eq!(
             parse!(year: 2012, ordinal: 182, hour_div_12: 1, hour_mod_12: 11,
-                          minute: 59, second: 60, timestamp: 1_341_100_801),
+                   minute: 59, second: 60, timestamp: 1_341_100_801),
             Err(IMPOSSIBLE)
         );
-
-        // error codes
-        assert_eq!(
-            parse!(year: 2015, month: 1, day: 20, weekday: Tue,
-                          hour_div_12: 2, hour_mod_12: 1, minute: 35, second: 20),
-            Err(OUT_OF_RANGE)
-        ); // `hour_div_12` is out of range
     }
 
     #[test]

--- a/src/format/parsed.rs
+++ b/src/format/parsed.rs
@@ -568,9 +568,7 @@ impl Parsed {
             }
 
             // reconstruct date and time fields from timestamp
-            let ts = timestamp.checked_add(i64::from(offset)).ok_or(OUT_OF_RANGE)?;
-            let datetime = NaiveDateTime::from_timestamp(ts, 0);
-            let mut datetime = datetime.ok_or(OUT_OF_RANGE)?;
+            let mut datetime = NaiveDateTime::from_timestamp(timestamp, 0).ok_or(OUT_OF_RANGE)?;
 
             // fill year, ordinal, hour, minute and second fields from timestamp.
             // if existing fields are consistent, this will allow the full date/time reconstruction.
@@ -1278,7 +1276,7 @@ mod tests {
             parse!(FixedOffset::east(32400).unwrap(); timestamp: 1_420_000_000, offset: 32400),
             Ok(FixedOffset::east(32400)
                 .unwrap()
-                .with_ymd_and_hms(2014, 12, 31, 13, 26, 40)
+                .with_ymd_and_hms(2014, 12, 31, 04, 26, 40)
                 .unwrap())
         );
 

--- a/src/format/parsed.rs
+++ b/src/format/parsed.rs
@@ -20,86 +20,26 @@ use crate::{DateTime, Datelike, TimeDelta, Timelike, Weekday};
 /// - Methods to inspect the parsed fields.
 #[derive(Clone, PartialEq, Eq, Debug, Default, Hash)]
 pub struct Parsed {
-    /// Year.
-    ///
-    /// This can be negative unlike [`year_div_100`](#structfield.year_div_100)
-    /// and [`year_mod_100`](#structfield.year_mod_100) fields.
-    pub year: Option<i32>,
-
-    /// Year divided by 100. Implies that the year is >= 1 BCE when set.
-    ///
-    /// Due to the common usage, if this field is missing but
-    /// [`year_mod_100`](#structfield.year_mod_100) is present,
-    /// it is inferred to 19 when `year_mod_100 >= 70` and 20 otherwise.
-    pub year_div_100: Option<i32>,
-
-    /// Year modulo 100. Implies that the year is >= 1 BCE when set.
-    pub year_mod_100: Option<i32>,
-
-    /// Year in the [ISO week date](../naive/struct.NaiveDate.html#week-date).
-    ///
-    /// This can be negative unlike [`isoyear_div_100`](#structfield.isoyear_div_100) and
-    /// [`isoyear_mod_100`](#structfield.isoyear_mod_100) fields.
-    pub isoyear: Option<i32>,
-
-    /// Year in the [ISO week date](../naive/struct.NaiveDate.html#week-date), divided by 100.
-    /// Implies that the year is >= 1 BCE when set.
-    ///
-    /// Due to the common usage, if this field is missing but
-    /// [`isoyear_mod_100`](#structfield.isoyear_mod_100) is present,
-    /// it is inferred to 19 when `isoyear_mod_100 >= 70` and 20 otherwise.
-    pub isoyear_div_100: Option<i32>,
-
-    /// Year in the [ISO week date](../naive/struct.NaiveDate.html#week-date), modulo 100.
-    /// Implies that the year is >= 1 BCE when set.
-    pub isoyear_mod_100: Option<i32>,
-
-    /// Month (1--12).
-    pub month: Option<u32>,
-
-    /// Week number, where the week 1 starts at the first Sunday of January
-    /// (0--53, 1--53 or 1--52 depending on the year).
-    pub week_from_sun: Option<u32>,
-
-    /// Week number, where the week 1 starts at the first Monday of January
-    /// (0--53, 1--53 or 1--52 depending on the year).
-    pub week_from_mon: Option<u32>,
-
-    /// [ISO week number](../naive/struct.NaiveDate.html#week-date)
-    /// (1--52 or 1--53 depending on the year).
-    pub isoweek: Option<u32>,
-
-    /// Day of the week.
-    pub weekday: Option<Weekday>,
-
-    /// Day of the year (1--365 or 1--366 depending on the year).
-    pub ordinal: Option<u32>,
-
-    /// Day of the month (1--28, 1--29, 1--30 or 1--31 depending on the month).
-    pub day: Option<u32>,
-
-    /// Hour number divided by 12 (0--1). 0 indicates AM and 1 indicates PM.
-    pub hour_div_12: Option<u32>,
-
-    /// Hour number modulo 12 (0--11).
-    pub hour_mod_12: Option<u32>,
-
-    /// Minute number (0--59).
-    pub minute: Option<u32>,
-
-    /// Second number (0--60, accounting for leap seconds).
-    pub second: Option<u32>,
-
-    /// The number of nanoseconds since the whole second (0--999,999,999).
-    pub nanosecond: Option<u32>,
-
-    /// The number of non-leap seconds since the midnight UTC on January 1, 1970.
-    ///
-    /// This can be off by one if [`second`](#structfield.second) is 60 (a leap second).
-    pub timestamp: Option<i64>,
-
-    /// Offset from the local time to UTC, in seconds.
-    pub offset: Option<i32>,
+    year: Option<i32>,
+    year_div_100: Option<i32>,
+    year_mod_100: Option<i32>,
+    isoyear: Option<i32>,
+    isoyear_div_100: Option<i32>,
+    isoyear_mod_100: Option<i32>,
+    month: Option<u32>,
+    week_from_sun: Option<u32>,
+    week_from_mon: Option<u32>,
+    isoweek: Option<u32>,
+    weekday: Option<Weekday>,
+    ordinal: Option<u32>,
+    day: Option<u32>,
+    hour_div_12: Option<u32>,
+    hour_mod_12: Option<u32>,
+    minute: Option<u32>,
+    second: Option<u32>,
+    nanosecond: Option<u32>,
+    timestamp: Option<i64>,
+    offset: Option<i32>,
 }
 
 /// Checks if `old` is either empty or has the same value as `new` (i.e. "consistent"),

--- a/src/format/parsed.rs
+++ b/src/format/parsed.rs
@@ -9,7 +9,7 @@ use crate::naive::{NaiveDate, NaiveDateTime, NaiveTime};
 use crate::offset::{FixedOffset, LocalResult, Offset, TimeZone};
 use crate::{DateTime, Datelike, TimeDelta, Timelike, Weekday};
 
-/// Parsed parts of date and time. There are two classes of methods:
+/// Parsed parts of date and time. There are three classes of methods:
 ///
 /// - `set_*` methods try to set given field(s) while checking for the consistency.
 ///   It may or may not check for the range constraint immediately (for efficiency reasons).
@@ -17,6 +17,8 @@ use crate::{DateTime, Datelike, TimeDelta, Timelike, Weekday};
 /// - `to_*` methods try to make a concrete date and time value out of set fields.
 ///   It fully checks any remaining out-of-range conditions and inconsistent/impossible fields.
 #[non_exhaustive]
+///
+/// - Methods to inspect the parsed fields.
 #[derive(Clone, PartialEq, Eq, Debug, Default, Hash)]
 pub struct Parsed {
     /// Year.
@@ -301,6 +303,175 @@ impl Parsed {
     pub fn set_offset(&mut self, value: i64) -> ParseResult<&mut Parsed> {
         set_if_consistent(&mut self.offset, i32::try_from(value).map_err(|_| OUT_OF_RANGE)?)?;
         Ok(self)
+    }
+
+    /// Get the 'year' field if set.
+    ///
+    /// See also [`set_year`](Parsed::set_year).
+    #[inline]
+    pub fn year(&self) -> Option<i32> {
+        self.year
+    }
+
+    /// Get the 'year divided by 100' field if set.
+    ///
+    /// See also [`set_year_div_100`](Parsed::set_year_div_100).
+    #[inline]
+    pub fn year_div_100(&self) -> Option<i32> {
+        self.year_div_100
+    }
+
+    /// Get the 'year modulo 100' field if set.
+    ///
+    /// See also [`set_year_mod_100`](Parsed::set_year_mod_100).
+    #[inline]
+    pub fn year_mod_100(&self) -> Option<i32> {
+        self.year_mod_100
+    }
+
+    /// Get the 'year' field that is part of an [ISO 8601 week date] if set.
+    ///
+    /// See also [`set_isoyear`](Parsed::set_isoyear).
+    ///
+    /// [ISO 8601 week date]: crate::NaiveDate#week-date
+    #[inline]
+    pub fn isoyear(&self) -> Option<i32> {
+        self.isoyear
+    }
+
+    /// Get the 'year divided by 100' field that is part of an [ISO 8601 week date] if set.
+    ///
+    /// See also [`set_isoyear_div_100`](Parsed::set_isoyear_div_100).
+    ///
+    /// [ISO 8601 week date]: crate::NaiveDate#week-date
+    #[inline]
+    pub fn isoyear_div_100(&self) -> Option<i32> {
+        self.isoyear_div_100
+    }
+
+    /// Get the 'year modulo 100' field that is part of an [ISO 8601 week date] if set.
+    ///
+    /// See also [`set_isoyear_mod_100`](Parsed::set_isoyear_mod_100).
+    ///
+    /// [ISO 8601 week date]: crate::NaiveDate#week-date
+    #[inline]
+    pub fn isoyear_mod_100(&self) -> Option<i32> {
+        self.isoyear_mod_100
+    }
+
+    /// Get the 'month' field if set.
+    ///
+    /// See also [`set_month`](Parsed::set_month).
+    #[inline]
+    pub fn month(&self) -> Option<u32> {
+        self.month
+    }
+
+    /// Get the 'week number starting with Sunday' field if set.
+    ///
+    /// See also [`set_week_from_sun`](Parsed::set_week_from_sun).
+    #[inline]
+    pub fn week_from_sun(&self) -> Option<u32> {
+        self.week_from_sun
+    }
+
+    /// Get the 'week number starting with Monday' field if set.
+    ///
+    /// See also [`set_week_from_mon`](Parsed::set_week_from_mon).
+    #[inline]
+    pub fn week_from_mon(&self) -> Option<u32> {
+        self.week_from_mon
+    }
+
+    /// Get the '[ISO 8601 week number]' field if set.
+    ///
+    /// See also [`set_isoweek`](Parsed::set_isoweek).
+    ///
+    /// [ISO 8601 week number]: crate::NaiveDate#week-date
+    #[inline]
+    pub fn isoweek(&self) -> Option<u32> {
+        self.isoweek
+    }
+
+    /// Get the 'day of the week' field if set.
+    ///
+    /// See also [`set_weekday`](Parsed::set_weekday).
+    #[inline]
+    pub fn weekday(&self) -> Option<Weekday> {
+        self.weekday
+    }
+
+    /// Get the 'ordinal' (day of the year) field if set.
+    ///
+    /// See also [`set_ordinal`](Parsed::set_ordinal).
+    #[inline]
+    pub fn ordinal(&self) -> Option<u32> {
+        self.ordinal
+    }
+
+    /// Get the 'day of the month' field if set.
+    ///
+    /// See also [`set_day`](Parsed::set_day).
+    #[inline]
+    pub fn day(&self) -> Option<u32> {
+        self.day
+    }
+
+    /// Get the 'hour divided by 12' field (am/pm) if set.
+    ///
+    /// See also [`set_ampm`](Parsed::set_ampm) and [`set_hour`](Parsed::set_hour).
+    ///
+    /// 0 indicates AM and 1 indicates PM.
+    #[inline]
+    pub fn hour_div_12(&self) -> Option<u32> {
+        self.hour_div_12
+    }
+
+    /// Get the 'hour modulo 12' field if set.
+    ///
+    /// See also [`set_hour12`](Parsed::set_hour12) and [`set_hour`](Parsed::set_hour).
+    pub fn hour_mod_12(&self) -> Option<u32> {
+        self.hour_mod_12
+    }
+
+    /// Get the 'minute' field if set.
+    ///
+    /// See also [`set_minute`](Parsed::set_minute).
+    #[inline]
+    pub fn minute(&self) -> Option<u32> {
+        self.minute
+    }
+
+    /// Get the 'second' field if set.
+    ///
+    /// See also [`set_second`](Parsed::set_second).
+    #[inline]
+    pub fn second(&self) -> Option<u32> {
+        self.second
+    }
+
+    /// Get the 'nanosecond' field if set.
+    ///
+    /// See also [`set_nanosecond`](Parsed::set_nanosecond).
+    #[inline]
+    pub fn nanosecond(&self) -> Option<u32> {
+        self.nanosecond
+    }
+
+    /// Get the 'timestamp' field if set.
+    ///
+    /// See also [`set_timestamp`](Parsed::set_timestamp).
+    #[inline]
+    pub fn timestamp(&self) -> Option<i64> {
+        self.timestamp
+    }
+
+    /// Get the 'offset' field if set.
+    ///
+    /// See also [`set_offset`](Parsed::set_offset).
+    #[inline]
+    pub fn offset(&self) -> Option<i32> {
+        self.offset
     }
 
     /// Returns a parsed naive date out of given fields.

--- a/src/format/parsed.rs
+++ b/src/format/parsed.rs
@@ -305,7 +305,7 @@ impl Parsed {
                 // we should filter a negative full year first.
                 (Some(y), q, r @ Some(0..=99)) | (Some(y), q, r @ None) => {
                     if y < 0 {
-                        return Err(OUT_OF_RANGE);
+                        return Err(IMPOSSIBLE);
                     }
                     let q_ = y / 100;
                     let r_ = y % 100;
@@ -320,7 +320,7 @@ impl Parsed {
                 // reconstruct the full year. make sure that the result is always positive.
                 (None, Some(q), Some(r @ 0..=99)) => {
                     if q < 0 {
-                        return Err(OUT_OF_RANGE);
+                        return Err(IMPOSSIBLE);
                     }
                     let y = q.checked_mul(100).and_then(|v| v.checked_add(r));
                     Ok(Some(y.ok_or(OUT_OF_RANGE)?))

--- a/src/format/parsed.rs
+++ b/src/format/parsed.rs
@@ -126,155 +126,181 @@ impl Parsed {
 
     /// Tries to set the [`year`](#structfield.year) field from given value.
     #[inline]
-    pub fn set_year(&mut self, value: i64) -> ParseResult<()> {
-        set_if_consistent(&mut self.year, i32::try_from(value).map_err(|_| OUT_OF_RANGE)?)
+    pub fn set_year(&mut self, value: i64) -> ParseResult<&mut Parsed> {
+        set_if_consistent(&mut self.year, i32::try_from(value).map_err(|_| OUT_OF_RANGE)?)?;
+        Ok(self)
     }
 
     /// Tries to set the [`year_div_100`](#structfield.year_div_100) field from given value.
     #[inline]
-    pub fn set_year_div_100(&mut self, value: i64) -> ParseResult<()> {
+    pub fn set_year_div_100(&mut self, value: i64) -> ParseResult<&mut Parsed> {
         if value < 0 {
             return Err(OUT_OF_RANGE);
         }
-        set_if_consistent(&mut self.year_div_100, i32::try_from(value).map_err(|_| OUT_OF_RANGE)?)
+        set_if_consistent(&mut self.year_div_100, i32::try_from(value).map_err(|_| OUT_OF_RANGE)?)?;
+        Ok(self)
     }
 
     /// Tries to set the [`year_mod_100`](#structfield.year_mod_100) field from given value.
     #[inline]
-    pub fn set_year_mod_100(&mut self, value: i64) -> ParseResult<()> {
+    pub fn set_year_mod_100(&mut self, value: i64) -> ParseResult<&mut Parsed> {
         if value < 0 {
             return Err(OUT_OF_RANGE);
         }
-        set_if_consistent(&mut self.year_mod_100, i32::try_from(value).map_err(|_| OUT_OF_RANGE)?)
+        set_if_consistent(&mut self.year_mod_100, i32::try_from(value).map_err(|_| OUT_OF_RANGE)?)?;
+        Ok(self)
     }
 
     /// Tries to set the [`isoyear`](#structfield.isoyear) field from given value.
     #[inline]
-    pub fn set_isoyear(&mut self, value: i64) -> ParseResult<()> {
-        set_if_consistent(&mut self.isoyear, i32::try_from(value).map_err(|_| OUT_OF_RANGE)?)
+    pub fn set_isoyear(&mut self, value: i64) -> ParseResult<&mut Parsed> {
+        set_if_consistent(&mut self.isoyear, i32::try_from(value).map_err(|_| OUT_OF_RANGE)?)?;
+        Ok(self)
     }
 
     /// Tries to set the [`isoyear_div_100`](#structfield.isoyear_div_100) field from given value.
     #[inline]
-    pub fn set_isoyear_div_100(&mut self, value: i64) -> ParseResult<()> {
+    pub fn set_isoyear_div_100(&mut self, value: i64) -> ParseResult<&mut Parsed> {
         if value < 0 {
             return Err(OUT_OF_RANGE);
         }
         set_if_consistent(
             &mut self.isoyear_div_100,
             i32::try_from(value).map_err(|_| OUT_OF_RANGE)?,
-        )
+        )?;
+        Ok(self)
     }
 
     /// Tries to set the [`isoyear_mod_100`](#structfield.isoyear_mod_100) field from given value.
     #[inline]
-    pub fn set_isoyear_mod_100(&mut self, value: i64) -> ParseResult<()> {
+    pub fn set_isoyear_mod_100(&mut self, value: i64) -> ParseResult<&mut Parsed> {
         if value < 0 {
             return Err(OUT_OF_RANGE);
         }
         set_if_consistent(
             &mut self.isoyear_mod_100,
             i32::try_from(value).map_err(|_| OUT_OF_RANGE)?,
-        )
+        )?;
+        Ok(self)
     }
 
     /// Tries to set the [`month`](#structfield.month) field from given value.
     #[inline]
-    pub fn set_month(&mut self, value: i64) -> ParseResult<()> {
-        set_if_consistent(&mut self.month, u32::try_from(value).map_err(|_| OUT_OF_RANGE)?)
+    pub fn set_month(&mut self, value: i64) -> ParseResult<&mut Parsed> {
+        set_if_consistent(&mut self.month, u32::try_from(value).map_err(|_| OUT_OF_RANGE)?)?;
+        Ok(self)
     }
 
     /// Tries to set the [`week_from_sun`](#structfield.week_from_sun) field from given value.
     #[inline]
-    pub fn set_week_from_sun(&mut self, value: i64) -> ParseResult<()> {
-        set_if_consistent(&mut self.week_from_sun, u32::try_from(value).map_err(|_| OUT_OF_RANGE)?)
+    pub fn set_week_from_sun(&mut self, value: i64) -> ParseResult<&mut Parsed> {
+        set_if_consistent(
+            &mut self.week_from_sun,
+            u32::try_from(value).map_err(|_| OUT_OF_RANGE)?,
+        )?;
+        Ok(self)
     }
 
     /// Tries to set the [`week_from_mon`](#structfield.week_from_mon) field from given value.
     #[inline]
-    pub fn set_week_from_mon(&mut self, value: i64) -> ParseResult<()> {
-        set_if_consistent(&mut self.week_from_mon, u32::try_from(value).map_err(|_| OUT_OF_RANGE)?)
+    pub fn set_week_from_mon(&mut self, value: i64) -> ParseResult<&mut Parsed> {
+        set_if_consistent(
+            &mut self.week_from_mon,
+            u32::try_from(value).map_err(|_| OUT_OF_RANGE)?,
+        )?;
+        Ok(self)
     }
 
     /// Tries to set the [`isoweek`](#structfield.isoweek) field from given value.
     #[inline]
-    pub fn set_isoweek(&mut self, value: i64) -> ParseResult<()> {
-        set_if_consistent(&mut self.isoweek, u32::try_from(value).map_err(|_| OUT_OF_RANGE)?)
+    pub fn set_isoweek(&mut self, value: i64) -> ParseResult<&mut Parsed> {
+        set_if_consistent(&mut self.isoweek, u32::try_from(value).map_err(|_| OUT_OF_RANGE)?)?;
+        Ok(self)
     }
 
     /// Tries to set the [`weekday`](#structfield.weekday) field from given value.
     #[inline]
-    pub fn set_weekday(&mut self, value: Weekday) -> ParseResult<()> {
-        set_if_consistent(&mut self.weekday, value)
+    pub fn set_weekday(&mut self, value: Weekday) -> ParseResult<&mut Parsed> {
+        set_if_consistent(&mut self.weekday, value)?;
+        Ok(self)
     }
 
     /// Tries to set the [`ordinal`](#structfield.ordinal) field from given value.
     #[inline]
-    pub fn set_ordinal(&mut self, value: i64) -> ParseResult<()> {
-        set_if_consistent(&mut self.ordinal, u32::try_from(value).map_err(|_| OUT_OF_RANGE)?)
+    pub fn set_ordinal(&mut self, value: i64) -> ParseResult<&mut Parsed> {
+        set_if_consistent(&mut self.ordinal, u32::try_from(value).map_err(|_| OUT_OF_RANGE)?)?;
+        Ok(self)
     }
 
     /// Tries to set the [`day`](#structfield.day) field from given value.
     #[inline]
-    pub fn set_day(&mut self, value: i64) -> ParseResult<()> {
-        set_if_consistent(&mut self.day, u32::try_from(value).map_err(|_| OUT_OF_RANGE)?)
+    pub fn set_day(&mut self, value: i64) -> ParseResult<&mut Parsed> {
+        set_if_consistent(&mut self.day, u32::try_from(value).map_err(|_| OUT_OF_RANGE)?)?;
+        Ok(self)
     }
 
     /// Tries to set the [`hour_div_12`](#structfield.hour_div_12) field from given value.
     /// (`false` for AM, `true` for PM)
     #[inline]
-    pub fn set_ampm(&mut self, value: bool) -> ParseResult<()> {
-        set_if_consistent(&mut self.hour_div_12, u32::from(value))
+    pub fn set_ampm(&mut self, value: bool) -> ParseResult<&mut Parsed> {
+        set_if_consistent(&mut self.hour_div_12, u32::from(value))?;
+        Ok(self)
     }
 
     /// Tries to set the [`hour_mod_12`](#structfield.hour_mod_12) field from
     /// given hour number in 12-hour clocks.
     #[inline]
-    pub fn set_hour12(&mut self, value: i64) -> ParseResult<()> {
+    pub fn set_hour12(&mut self, value: i64) -> ParseResult<&mut Parsed> {
         if !(1..=12).contains(&value) {
             return Err(OUT_OF_RANGE);
         }
-        set_if_consistent(&mut self.hour_mod_12, value as u32 % 12)
+        set_if_consistent(&mut self.hour_mod_12, value as u32 % 12)?;
+        Ok(self)
     }
 
     /// Tries to set both [`hour_div_12`](#structfield.hour_div_12) and
     /// [`hour_mod_12`](#structfield.hour_mod_12) fields from given value.
     #[inline]
-    pub fn set_hour(&mut self, value: i64) -> ParseResult<()> {
+    pub fn set_hour(&mut self, value: i64) -> ParseResult<&mut Parsed> {
         let v = u32::try_from(value).map_err(|_| OUT_OF_RANGE)?;
         set_if_consistent(&mut self.hour_div_12, v / 12)?;
         set_if_consistent(&mut self.hour_mod_12, v % 12)?;
-        Ok(())
+        Ok(self)
     }
 
     /// Tries to set the [`minute`](#structfield.minute) field from given value.
     #[inline]
-    pub fn set_minute(&mut self, value: i64) -> ParseResult<()> {
-        set_if_consistent(&mut self.minute, u32::try_from(value).map_err(|_| OUT_OF_RANGE)?)
+    pub fn set_minute(&mut self, value: i64) -> ParseResult<&mut Parsed> {
+        set_if_consistent(&mut self.minute, u32::try_from(value).map_err(|_| OUT_OF_RANGE)?)?;
+        Ok(self)
     }
 
     /// Tries to set the [`second`](#structfield.second) field from given value.
     #[inline]
-    pub fn set_second(&mut self, value: i64) -> ParseResult<()> {
-        set_if_consistent(&mut self.second, u32::try_from(value).map_err(|_| OUT_OF_RANGE)?)
+    pub fn set_second(&mut self, value: i64) -> ParseResult<&mut Parsed> {
+        set_if_consistent(&mut self.second, u32::try_from(value).map_err(|_| OUT_OF_RANGE)?)?;
+        Ok(self)
     }
 
     /// Tries to set the [`nanosecond`](#structfield.nanosecond) field from given value.
     #[inline]
-    pub fn set_nanosecond(&mut self, value: i64) -> ParseResult<()> {
-        set_if_consistent(&mut self.nanosecond, u32::try_from(value).map_err(|_| OUT_OF_RANGE)?)
+    pub fn set_nanosecond(&mut self, value: i64) -> ParseResult<&mut Parsed> {
+        set_if_consistent(&mut self.nanosecond, u32::try_from(value).map_err(|_| OUT_OF_RANGE)?)?;
+        Ok(self)
     }
 
     /// Tries to set the [`timestamp`](#structfield.timestamp) field from given value.
     #[inline]
-    pub fn set_timestamp(&mut self, value: i64) -> ParseResult<()> {
-        set_if_consistent(&mut self.timestamp, value)
+    pub fn set_timestamp(&mut self, value: i64) -> ParseResult<&mut Parsed> {
+        set_if_consistent(&mut self.timestamp, value)?;
+        Ok(self)
     }
 
     /// Tries to set the [`offset`](#structfield.offset) field from given value.
     #[inline]
-    pub fn set_offset(&mut self, value: i64) -> ParseResult<()> {
-        set_if_consistent(&mut self.offset, i32::try_from(value).map_err(|_| OUT_OF_RANGE)?)
+    pub fn set_offset(&mut self, value: i64) -> ParseResult<&mut Parsed> {
+        set_if_consistent(&mut self.offset, i32::try_from(value).map_err(|_| OUT_OF_RANGE)?)?;
+        Ok(self)
     }
 
     /// Returns a parsed naive date out of given fields.
@@ -702,69 +728,69 @@ mod tests {
     fn test_parsed_set_fields() {
         // year*, isoyear*
         let mut p = Parsed::new();
-        assert_eq!(p.set_year(1987), Ok(()));
+        assert!(p.set_year(1987).is_ok());
         assert_eq!(p.set_year(1986), Err(IMPOSSIBLE));
         assert_eq!(p.set_year(1988), Err(IMPOSSIBLE));
-        assert_eq!(p.set_year(1987), Ok(()));
-        assert_eq!(p.set_year_div_100(20), Ok(())); // independent to `year`
+        assert!(p.set_year(1987).is_ok());
+        assert!(p.set_year_div_100(20).is_ok()); // independent to `year`
         assert_eq!(p.set_year_div_100(21), Err(IMPOSSIBLE));
         assert_eq!(p.set_year_div_100(19), Err(IMPOSSIBLE));
-        assert_eq!(p.set_year_mod_100(37), Ok(())); // ditto
+        assert!(p.set_year_mod_100(37).is_ok()); // ditto
         assert_eq!(p.set_year_mod_100(38), Err(IMPOSSIBLE));
         assert_eq!(p.set_year_mod_100(36), Err(IMPOSSIBLE));
 
         let mut p = Parsed::new();
-        assert_eq!(p.set_year(0), Ok(()));
-        assert_eq!(p.set_year_div_100(0), Ok(()));
-        assert_eq!(p.set_year_mod_100(0), Ok(()));
+        assert!(p.set_year(0).is_ok());
+        assert!(p.set_year_div_100(0).is_ok());
+        assert!(p.set_year_mod_100(0).is_ok());
 
         let mut p = Parsed::new();
         assert_eq!(p.set_year_div_100(-1), Err(OUT_OF_RANGE));
         assert_eq!(p.set_year_mod_100(-1), Err(OUT_OF_RANGE));
-        assert_eq!(p.set_year(-1), Ok(()));
+        assert!(p.set_year(-1).is_ok());
         assert_eq!(p.set_year(-2), Err(IMPOSSIBLE));
         assert_eq!(p.set_year(0), Err(IMPOSSIBLE));
 
         let mut p = Parsed::new();
         assert_eq!(p.set_year_div_100(0x1_0000_0008), Err(OUT_OF_RANGE));
-        assert_eq!(p.set_year_div_100(8), Ok(()));
+        assert!(p.set_year_div_100(8).is_ok());
         assert_eq!(p.set_year_div_100(0x1_0000_0008), Err(OUT_OF_RANGE));
 
         // month, week*, isoweek, ordinal, day, minute, second, nanosecond, offset
         let mut p = Parsed::new();
-        assert_eq!(p.set_month(7), Ok(()));
+        assert!(p.set_month(7).is_ok());
         assert_eq!(p.set_month(1), Err(IMPOSSIBLE));
         assert_eq!(p.set_month(6), Err(IMPOSSIBLE));
         assert_eq!(p.set_month(8), Err(IMPOSSIBLE));
         assert_eq!(p.set_month(12), Err(IMPOSSIBLE));
 
         let mut p = Parsed::new();
-        assert_eq!(p.set_month(8), Ok(()));
+        assert!(p.set_month(8).is_ok());
         assert_eq!(p.set_month(0x1_0000_0008), Err(OUT_OF_RANGE));
 
         // hour
         let mut p = Parsed::new();
-        assert_eq!(p.set_hour(12), Ok(()));
+        assert!(p.set_hour(12).is_ok());
         assert_eq!(p.set_hour(11), Err(IMPOSSIBLE));
         assert_eq!(p.set_hour(13), Err(IMPOSSIBLE));
-        assert_eq!(p.set_hour(12), Ok(()));
+        assert!(p.set_hour(12).is_ok());
         assert_eq!(p.set_ampm(false), Err(IMPOSSIBLE));
-        assert_eq!(p.set_ampm(true), Ok(()));
-        assert_eq!(p.set_hour12(12), Ok(()));
+        assert!(p.set_ampm(true).is_ok());
+        assert!(p.set_hour12(12).is_ok());
         assert_eq!(p.set_hour12(0), Err(OUT_OF_RANGE)); // requires canonical representation
         assert_eq!(p.set_hour12(1), Err(IMPOSSIBLE));
         assert_eq!(p.set_hour12(11), Err(IMPOSSIBLE));
 
         let mut p = Parsed::new();
-        assert_eq!(p.set_ampm(true), Ok(()));
-        assert_eq!(p.set_hour12(7), Ok(()));
+        assert!(p.set_ampm(true).is_ok());
+        assert!(p.set_hour12(7).is_ok());
         assert_eq!(p.set_hour(7), Err(IMPOSSIBLE));
         assert_eq!(p.set_hour(18), Err(IMPOSSIBLE));
-        assert_eq!(p.set_hour(19), Ok(()));
+        assert!(p.set_hour(19).is_ok());
 
         // timestamp
         let mut p = Parsed::new();
-        assert_eq!(p.set_timestamp(1_234_567_890), Ok(()));
+        assert!(p.set_timestamp(1_234_567_890).is_ok());
         assert_eq!(p.set_timestamp(1_234_567_889), Err(IMPOSSIBLE));
         assert_eq!(p.set_timestamp(1_234_567_891), Err(IMPOSSIBLE));
     }


### PR DESCRIPTION
I intend to split this PR in multiple parts, but opened it for discussion on how best to do so.

The main goal is to move all range validation to the `Parsed::set_*` methods.

It has four pieces:

### 1. For the 0.4 branch
We have two small bugs in our implementation of `Parsed`:
- If there is a timestamp and an offset field, the offset is added to the timestamp. But the definition of a Unix timestamp is that the value is in UTC, so this is not correct.
- We were returning `OUT_OF_RANGE` if the year value didn't match with values of `year_div_100` or `year_mod_100`. It should return `IMPOSSIBLE` instead.

### 2. Documentation
I have added documentation to all methods describing their error causes. And the `Parsed` type got some documentation describing why it exists (the resolution algorithm), and an example of how to use it. Partly taken from the blog post before chrono 0.2: https://lifthrasiir.github.io/rustlog/worklog-2015-02-19.html

### 3. Goal: move all range validation to the `set_*` methods
The goal of this PR was to move all range validation to the `set_*` methods.

Currently the `set_*` methods do a partial range check, or just a checked cast, and the `to_*` methods do the complete range checks. Doing them all in the `set_*` methods will allow us to give more a precise error when we convert the parsing code to the new error type. (It can then return the position in the format string where an invalid value appeared.)

### 4. Nice to have
It would be nice if the `to_` methods can rely on the range checks performed by `set_*`.
But currently they can't because the fields of `Parsed` are public.

*Making the fields private* seems like a good thing to do for this type in general. It involves:
- Adding functions to get each individual field.
- Changing the macro-heavy tests in `format::parse` to use the `set_*` methods.

As a clean solution to replacing the macro's I changed the return type of the `set_*` methods to be usable as a *builder pattern*.

### How to split
1. I can open a PR to the 0.4 branch with the bug fixes.
2. I can also backport the documentation changes. They will be a bit less nice without the builder pattern and with more error cases.
3. We could bring the range validation in the `set_*` methods to the 0.4 branch. We already document they do range checks, only that they may not have been precise and delay the error until the `to_*` methods.
4. Converting the `set_*` methods to a builder pattern, making the fields of `Parsed` private and simplifying the `to_*` methods require 0.5. None of those are strictly *necessary*, but they do improve our error story and are nice to have.